### PR TITLE
Fix syntax and clarified steps in Traditional Setup Guide

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -128,12 +128,12 @@ _Please Read [How to edit .conf files](how-to-work-with-conf-files.md) article t
 Open both `authserver.conf` and `worldserver.conf` files and go to the `MYSQL SETTINGS` section, then set the variables:
 
 ```
-LoginDatabaseInfo     = "127.0.0.1;3306;root;your_password;acore_auth"
-WorldDatabaseInfo     = "127.0.0.1;3306;root;your_password;acore_world"
-CharacterDatabaseInfo = "127.0.0.1;3306;root;your_password;acore_characters"
+LoginDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_auth"
+WorldDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_world"
+CharacterDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_characters"
 ```
 
-replacing `your_password` with the password of your MySQL server root user
+The default user is `acore` with password `acore`. If you would like to use another MySQL user, change the credentials here.
 (the `authserver.conf` has the `LoginDatabaseInfo` variable only).
 
 In the worldserver.conf file, also set:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -177,7 +177,7 @@ Follow these instructions: [Database Setup](Database-Setup).
 ### Configure your auth.realmlist table
 
 In the `acore_auth` database, you must fill the `realmlist` table with your connection info.
-It must correspond with the values in worldserver.conf (for realmid, flag and realmzone).
+It must correspond with the values in `worldserver.conf` (for realmid, flag and realmzone).
 
 	Address: 127.0.0.1 OR <Your LOCAL NETWORK ip>  OR <Your PUBLIC NETWORK ip>
 	Port :	worldserver port

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -79,7 +79,7 @@ make install
 
 ### Compiling on Windows
 
-Open CMake , press `Browse Source...` button and select the folder that you cloned earlier then press `Browse Build...` and select a folder where the CMake will generate the build files. Press the `Configure` button.
+Open CMake, press `Browse Source...` button and select the folder that you cloned earlier then press `Browse Build...` and select a folder where the CMake will generate the build files. Press the `Configure` button.
 
 CMake will ask you to select what compiler to use. For example you'll want to select `Visual Studio 15 2017` to compile binaries using Visual Studio 2017. If you want to build using x64 set `Optional platform for generator` to x64. Do not change the `Use default native compilers` option. Press `Finish` and wait until CMake is done checking for requires files.
 
@@ -128,9 +128,9 @@ _Please Read [How to edit .conf files](how-to-work-with-conf-files.md) article t
 Open both `authserver.conf` and `worldserver.conf` files and go to the `MYSQL SETTINGS` section, then set the variables:
 
 ```
-LoginDatabaseInfo     = "127.0.0.1;3306;root;your_password;auth"
-WorldDatabaseInfo     = "127.0.0.1;3306;root;your_password;world"
-CharacterDatabaseInfo = "127.0.0.1;3306;root;your_password;characters"
+LoginDatabaseInfo     = "127.0.0.1;3306;root;your_password;acore_auth"
+WorldDatabaseInfo     = "127.0.0.1;3306;root;your_password;acore_world"
+CharacterDatabaseInfo = "127.0.0.1;3306;root;your_password;acore_characters"
 ```
 
 replacing `your_password` with the password of your MySQL server root user
@@ -140,12 +140,12 @@ In the worldserver.conf file, also set:
 
 `DataDir = "/home/youruser/azeroth-server/data"`
 
-replacing `/home/youruser/azeroth-server` with the path where you installed the binaries.
+replacing `/home/youruser/azeroth-server` with `CMAKE_INSTALL_PREFIX`.
 
 
 ## 5) Download the data files
 
-Go to the directory of your azeroth server (e.g. `/home/youruser/azeroth-server`) and create a new directory named `data`
+Go to `CMAKE_INSTALL_PREFIX` and create a new directory named `data`
 
 Two options to choose from:
 
@@ -176,8 +176,8 @@ Follow these instructions: [Database Setup](Database-Setup).
 
 ### Configure your auth.realmlist table
 
-In the `auth` database, you must fill the `realmlist` table with your connection info.
-It must correspond with your configuration file (for realmid, flag and realmzone).
+In the `acore_auth` database, you must fill the `realmlist` table with your connection info.
+It must correspond with the values in worldserver.conf (for realmid, flag and realmzone).
 
 	Address: 127.0.0.1 OR <Your LOCAL NETWORK ip>  OR <Your PUBLIC NETWORK ip>
 	Port :	worldserver port

--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -44,7 +44,7 @@ Then use it to install the required packages:
 
 * [MySQL Server Community Edition](http://dev.mysql.com/downloads/mysql/5.6.html) ( 5.6 or higher )
 
-* [Mysql Development File](https://docs.google.com/uc?id=0B1fF5EIDoF1fWjYwQ1FCNUJmMWc&export=download)
+* [MySQL Development File](https://docs.google.com/uc?id=0B1fF5EIDoF1fWjYwQ1FCNUJmMWc&export=download)
   
   These files are shipped with MySQL Server but to make it easier we packed the libs and include files for both 32 bits and 64 bits.
 
@@ -61,7 +61,7 @@ Then use it to install the required packages:
     1. Example: **Win32 OpenSSL v1.0.1p**
 
 3. _Note #1: If you get a "Missing Microsoft Visual C++ 2008 Redistributables" error message while installing OpenSSL, download the ** [Microsoft Visual C++ 2008 Redistributable Package (x64)](http://www.microsoft.com/en-us/download/details.aspx?id=29) ** (1.7MB Installer) and install it. If you need 32bit support, download and install the [ **Microsoft Visual C++ 2008 Redistributable Package (x86)** ](http://www.microsoft.com/en-us/download/details.aspx?id=15336)._
-4. _Note #2: While installing OpenSSL, choose **The OpenSSL binaries (/bin) directory** (NOT "The Windows system directory") when given the choice on where to copy the OpenSSL DLLs. These DLLs will need to be located easily for Core Installation
+4. _Note #2: While installing OpenSSL, choose **The OpenSSL binaries (/bin) directory** (NOT "The Windows system directory") when given the choice on where to copy the OpenSSL DLLs. These DLLs will need to be located easily for Core Installation._
 
 ***
 


### PR DESCRIPTION
## Description
I went through the installation steps defined in `Installation.md` and `Requirements.md` and clarified any inconsistencies I encountered.
- Added reference to `CMAKE_INSTALL_PREFIX` when referring to the location of the server, build artifacts and binaries.
- prepended `acore` to db names for when setting `MYSQL SETTINGS` for the first time.
- fixed formatting inconsistencies. 
