### PR TITLE
Documentation for the new script command SCRIPT_COMMAND_MOVEMENT (35)

### DIFF
--- a/docs/database-world.md
+++ b/docs/database-world.md
@@ -132,6 +132,7 @@ NOTE: the DB documentation is still a work in progress. We need your help to mak
 - [reputation_reward_rate](reputation_reward_rate.md)
 - [reputation_spillover_template](reputation_spillover_template.md)
 - [script_waypoint](script_waypoint.md)
+- [scripts](scripts.md)
 - [skill_discovery_template](skill_discovery_template.md)
 - [skill_extra_item_template](skill_extra_item_template.md)
 - [skill_fishing_base_level](skill_fishing_base_level.md)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -241,6 +241,7 @@ The type of action performed by the script after [delay](#scripts-delay) seconds
 | 32      | MODEL                  | Sets creature model.                                                     |
 | 33      | CLOSE\_GOSSIP          | Closes gossip window. This command is only used for Gossip Scripts.      |
 | 34      | PLAYMOVIE              | Plays movie.                                                             |
+| 35      | MOVEMENT               | Change movement type.                                                    |
 
 ### OtherFields
 
@@ -428,6 +429,13 @@ Depending on what command was used, the meaning and use for the following fields
 
 -   -   source: Player.
     -   datalong: movie ID.
+
+\***SCRIPT\_COMMAND\_MOVEMENT = 35**
+
+-   -   source: Creature.
+    -   datalong: MovementType.
+    -   datalong2: MovementDistance (e.g. spawndist for MovementType 1).
+    -   dataint: pathid (for MovementType 2, see [waypoint\_data.id](waypoint_data.md#id)).
 
 ### guid
 


### PR DESCRIPTION
- Add documentation for the new script command SCRIPT_COMMAND_MOVEMENT (35)
 (see https://github.com/azerothcore/azerothcore-wotlk/pull/1721)
- Add "scripts"-link to "database-world.md" as this seems to be missing