### PR TITLE
smart_scripts: update action types 8, 60, 116-120

### DIFF
--- a/docs/smart_scripts.md
+++ b/docs/smart_scripts.md
@@ -3490,7 +3490,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 </tr>
 <tr class="odd">
-<td>SMART_ACTION_SET_CORPSE_DELAY</td>
+<td>SMART_ACTION_SET_CORPSE_DELAY
+<p style="color: red">(Not supported yet)</p></td>
 <td>116</td>
 <td>timer</td>
 <td><br />
@@ -3503,10 +3504,12 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><p>Not supported yet</p></td>
+<td><br />
+</td>
 </tr>
 <tr class="even">
-<td>SMART_ACTION_DISABLE_EVADE</td>
+<td>SMART_ACTION_DISABLE_EVADE
+<p style="color: red">(Not supported yet)</p></td>
 <td>117</td>
 <td>disable evade (1) / re-enable (0)</td>
 <td><br />
@@ -3519,7 +3522,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><p>Not supported yet</p></td>
+<td><br />
+</td>
 </tr>
 <tr class="odd">
 <td>SMART_ACTION_GO_SET_GO_STATE</td>
@@ -3535,10 +3539,12 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><p>Not supported yet</p></td>
+<td><br />
+</td>
 </tr>
 <tr class="even">
-<td>SMART_ACTION_SET_CAN_FLY</td>
+<td>SMART_ACTION_SET_CAN_FLY
+<p style="color: red">(Not supported yet)</p></td>
 <td>119</td>
 <td>0/1</td>
 <td><br />
@@ -3551,10 +3557,12 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><p>Not supported yet</p></td>
+<td><br />
+</td>
 </tr>
 <tr class="odd">
-<td>SMART_ACTION_REMOVE_AURAS_BY_TYPE</td>
+<td>SMART_ACTION_REMOVE_AURAS_BY_TYPE
+<p style="color: red">(Not supported yet)</p></td>
 <td>120</td>
 <td>Type</td>
 <td><br />
@@ -3567,7 +3575,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><p>Not supported yet</p></td>
+<td><br />
+</td>
 </tr>
 <tr class="even">
 <td>SMART_ACTION_SET_SIGHT_DIST</td>

--- a/docs/smart_scripts.md
+++ b/docs/smart_scripts.md
@@ -3491,7 +3491,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </tr>
 <tr class="odd">
 <td>SMART_ACTION_SET_CORPSE_DELAY
-<p style="color: red">(Not supported yet)</p></td>
+<p>(Not supported yet)</p></td>
 <td>116</td>
 <td>timer</td>
 <td><br />
@@ -3509,7 +3509,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </tr>
 <tr class="even">
 <td>SMART_ACTION_DISABLE_EVADE
-<p style="color: red">(Not supported yet)</p></td>
+<p>(Not supported yet)</p></td>
 <td>117</td>
 <td>disable evade (1) / re-enable (0)</td>
 <td><br />
@@ -3526,7 +3526,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 </tr>
 <tr class="odd">
-<td>SMART_ACTION_GO_SET_GO_STATE</td>
+<td>SMART_ACTION_GO_SET_GO_STATE
+<p>(Not supported yet)</p></td>
 <td>118</td>
 <td>state</td>
 <td><br />
@@ -3544,7 +3545,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </tr>
 <tr class="even">
 <td>SMART_ACTION_SET_CAN_FLY
-<p style="color: red">(Not supported yet)</p></td>
+<p>(Not supported yet)</p></td>
 <td>119</td>
 <td>0/1</td>
 <td><br />
@@ -3562,7 +3563,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </tr>
 <tr class="odd">
 <td>SMART_ACTION_REMOVE_AURAS_BY_TYPE
-<p style="color: red">(Not supported yet)</p></td>
+<p>(Not supported yet)</p></td>
 <td>120</td>
 <td>Type</td>
 <td><br />

--- a/docs/smart_scripts.md
+++ b/docs/smart_scripts.md
@@ -1805,7 +1805,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </p></td>
 <td><p><br />
 </p></td>
-<td><p>React State. Can be Passive (0), Defensive (1), Aggressive (2), Assist (3).</p></td>
+<td><p>React State. Can be Passive (0), Defensive (1), Aggressive (2).</p></td>
 </tr>
 <tr class="even">
 <td><p>SMART_ACTION_ACTIVATE_GOBJECT</p></td>
@@ -2604,13 +2604,11 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </p></td>
 </tr>
 <tr class="odd">
-<td><p>SMART_ACTION_SET_DISABLE_GRAVITY</p></td>
+<td><p>SMART_ACTION_SET_FLY</p></td>
 <td><p>60</p></td>
-<td><p>0 = On / 1 = Off</p></td>
-<td><p><br />
-</p></td>
-<td><p><br />
-</p></td>
+<td><p>fly (0/1)</p></td>
+<td><p>speed</p></td>
+<td><p>disable gravity (0/1)</p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3505,8 +3503,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><br />
-</td>
+<td><p>Not supported yet</p></td>
 </tr>
 <tr class="even">
 <td>SMART_ACTION_DISABLE_EVADE</td>
@@ -3522,8 +3519,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><br />
-</td>
+<td><p>Not supported yet</p></td>
 </tr>
 <tr class="odd">
 <td>SMART_ACTION_GO_SET_GO_STATE</td>
@@ -3539,8 +3535,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><br />
-</td>
+<td><p>Not supported yet</p></td>
 </tr>
 <tr class="even">
 <td>SMART_ACTION_SET_CAN_FLY</td>
@@ -3556,8 +3551,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><br />
-</td>
+<td><p>Not supported yet</p></td>
 </tr>
 <tr class="odd">
 <td>SMART_ACTION_REMOVE_AURAS_BY_TYPE</td>
@@ -3573,8 +3567,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </td>
 <td><br />
 </td>
-<td><br />
-</td>
+<td><p>Not supported yet</p></td>
 </tr>
 <tr class="even">
 <td>SMART_ACTION_SET_SIGHT_DIST</td>


### PR DESCRIPTION
Update smart_scripts documentation:
- action type SMART_ACTION_SET_REACT_STATE (8) does not support react state "assist" (3)
- renamed action type SMART_ACTION_SET_DISABLE_GRAVITY (60) to SMART_ACTION_SET_FLY and update the parameters (I don't know how this action type actually works so cannot provide further information, but this reflects the implementation of the parameters)
- mark action types 116-120 as not supported