### PR TITLE
Update conditions.md

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -65,7 +65,7 @@ This table allows you to define conditions for various systems - Gossip, loot et
 <td><p>0</p></td>
 <td><p><br />
 </p></td>
-<td><p><a href="https://trinitycore.atlassian.net/wiki/display/tc/smart_scripts#smart_scripts-source_type">smart_scripts.source_type</a> <strong>||</strong> 0 for everything else</p></td>
+<td><p><a href="http://www.azerothcore.org/wiki/smart_scripts#source_type">smart_scripts.source_type</a> <strong>||</strong> 0 for everything else</p></td>
 </tr>
 <tr class="even">
 <td><p><a href="#elsegroup">ElseGroup</a></p></td>
@@ -220,7 +220,7 @@ if negative, then it is a reference template.
 <th>ID</th>
 <th>SourceGroup</th>
 <th>SourceEntry</th>
-<th><a href="https://trinitycore.atlassian.net/wiki/display/tc/conditions#conditions-CONDITION_SOURCE_TYPE_SMART_EVENT=22">SourceId</a></th>
+<th><a href="http://www.azerothcore.org/wiki/conditions#condition_source_type_smart_event=22">SourceId</a></th>
 <th>ConditionTarget</th>
 <th>Notes</th>
 </tr>
@@ -238,8 +238,8 @@ if negative, then it is a reference template.
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_CREATURE_LOOT_TEMPLATE</td>
 <td>1</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">creature_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">creature_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -248,8 +248,8 @@ if negative, then it is a reference template.
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_DISENCHANT_LOOT_TEMPLATE</td>
 <td>2</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">disenchant_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">disenchant_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -258,8 +258,8 @@ if negative, then it is a reference template.
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_FISHING_LOOT_TEMPLATE</td>
 <td>3</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">fishing_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">fishing_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -268,8 +268,8 @@ if negative, then it is a reference template.
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_GAMEOBJECT_LOOT_TEMPLATE</td>
 <td>4</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">gameobject_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">gameobject_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -278,8 +278,8 @@ if negative, then it is a reference template.
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_ITEM_LOOT_TEMPLATE</td>
 <td>5</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">item_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">item_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -288,8 +288,8 @@ if negative, then it is a reference template.
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_MAIL_LOOT_TEMPLATE</td>
 <td>6</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">mail_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">mail_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -298,8 +298,8 @@ if negative, then it is a reference template.
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_MILLING_LOOT_TEMPLATE</td>
 <td>7</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">milling_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">milling_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -308,8 +308,8 @@ if negative, then it is a reference template.
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_PICKPOCKETING_LOOT_TEMPLATE</td>
 <td>8</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">pickpocketing_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">pickpocketing_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -318,8 +318,8 @@ if negative, then it is a reference template.
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_PROSPECTING_LOOT_TEMPLATE</td>
 <td>9</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">prospecting_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">prospecting_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -328,8 +328,8 @@ if negative, then it is a reference template.
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_REFERENCE_LOOT_TEMPLATE</td>
 <td>10</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -338,8 +338,8 @@ if negative, then it is a reference template.
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_SKINNING_LOOT_TEMPLATE</td>
 <td>11</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">skinning_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">skinning_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -348,8 +348,8 @@ if negative, then it is a reference template.
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_SPELL_LOOT_TEMPLATE</td>
 <td>12</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Entry">spell_loot_template.Entry or reference_loot_template.Entry</a></td>
-<td>item id (<a href="https://trinitycore.atlassian.net/wiki/display/tc/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
+<td><a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Entry">spell_loot_template.Entry or reference_loot_template.Entry</a></td>
+<td>item id (<a href="http://www.azerothcore.org/wiki/loot_template#loot_template-Item">_loot_template.Item or reference_loot_template.Item)</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -362,7 +362,7 @@ CONDITION_SOURCE_TYPE_SPELL_IMPLICIT_TARGET</td>
 13</td>
 <td>Mask of effects to be affected by condition:<br />
 1 = EFFECT_0, 2 = EFFECT_1, 4 = EFFECT_2</td>
-<td>Spell Id from  <a href="Spell">Spell DBC file</a></td>
+<td>Spell Id from  <a href="Spell">Spell.dbc</a></td>
 <td>Always 0</td>
 <td><p>0 : Potential spell Target<br />
 1 : spell Caster</p></td>
@@ -371,8 +371,8 @@ CONDITION_SOURCE_TYPE_SPELL_IMPLICIT_TARGET</td>
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_GOSSIP_MENU</td>
 <td>14</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/gossip_menu#gossip_menu-entry">gossip_menu.entry</a> (gossip menu entry)</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/gossip_menu#gossip_menu-text_id">gossip_menu.text_id</a> (points to npc_text.ID)</td>
+<td><a href="http://www.azerothcore.org/wiki/gossip_menu#entry">gossip_menu.entry</a> (gossip menu entry)</td>
+<td><a href="http://www.azerothcore.org/wiki/gossip_menu#text_id">gossip_menu.text_id</a> (points to npc_text.ID)</td>
 <td>Always 0</td>
 <td><p>0 = Player<br />
 1 = WorldObject</p></td>
@@ -382,8 +382,8 @@ CONDITION_SOURCE_TYPE_SPELL_IMPLICIT_TARGET</td>
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_GOSSIP_MENU_OPTION</td>
 <td>15</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/gossip_menu_option#gossip_menu_option-menu_id">gossip_menu_option.menu_id</a> (menu entry)</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/gossip_menu_option#gossip_menu_option-id">gossip_menu_option.id</a></td>
+<td><a href="http://www.azerothcore.org/wiki/gossip_menu_option#menu_id">gossip_menu_option.menu_id</a> (menu entry)</td>
+<td><a href="http://www.azerothcore.org/wiki/gossip_menu_option#id">gossip_menu_option.id</a></td>
 <td>Always 0</td>
 <td><p>0 = Player<br />
 1 = WorldObject</p></td>
@@ -394,7 +394,7 @@ CONDITION_SOURCE_TYPE_SPELL_IMPLICIT_TARGET</td>
 <td>CONDITION_SOURCE_TYPE_CREATURE_TEMPLATE_VEHICLE</td>
 <td>16</td>
 <td>Always 0</td>
-<td>creature entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-entry">creature_template.entry</a>)</td>
+<td>creature entry (<a href="http://www.azerothcore.org/wiki/creature_template#creature_template-entry">creature_template.entry</a>)</td>
 <td>Always 0</td>
 <td><p>0 = Player riding vehicle<br />
 1 = Vehicle creature</p></td>
@@ -420,7 +420,7 @@ CONDITION_SOURCE_TYPE_SPELL</td>
 <br />
 <br />
 <br />
-Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell">Spell.dbc</a></td>
+Spell ID from <a href="http://www.azerothcore.org/wiki/Spell">Spell.dbc</a></td>
 <td>Always 0</td>
 <td><br />
 <br />
@@ -437,8 +437,8 @@ Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell"
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_SPELL_CLICK_EVENT</td>
 <td>18</td>
-<td>creature entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/npc_spellclick_spells#npc_spellclick_spells-npc_entry">npc_spellclick_spells.npc_entry</a>)</td>
-<td>Spell (<a href="https://trinitycore.atlassian.net/wiki/display/tc/npc_spellclick_spells#npc_spellclick_spells-spell_id">npc_spellclick_spells.spell_id</a>)</td>
+<td>creature entry (<a href="http://www.azerothcore.org/wiki/npc_spellclick_spells#npc_entry">npc_spellclick_spells.npc_entry</a>)</td>
+<td>Spell (<a href="http://www.azerothcore.org/wiki/npc_spellclick_spells#spell_id">npc_spellclick_spells.spell_id</a>)</td>
 <td>Always 0</td>
 <td>0 = Clicker<br />
 1 =  Spellclick target (clickee)</td>
@@ -449,7 +449,7 @@ Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell"
 <td>CONDITION_SOURCE_TYPE_QUEST_AVAILABLE</td>
 <td>19</td>
 <td>Always 0</td>
-<td><a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">Quest ID</a></td>
+<td><a href="http://www.azerothcore.org/wiki/quest_template#id">Quest ID</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td>Condition must be met for quest to be available to player.</td>
@@ -472,9 +472,9 @@ Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell"
 CONDITION_SOURCE_TYPE_VEHICLE_SPELL</td>
 <td><br />
 21</td>
-<td>creature entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-entry">creature_template.entry</a>)</td>
+<td>creature entry (<a href="http://www.azerothcore.org/wiki/creature_template#creature_template-entry">creature_template.entry</a>)</td>
 <td><br />
-Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell">Spell.dbc</a></td>
+Spell ID from <a href="http://www.azerothcore.org/wiki/Spell">Spell.dbc</a></td>
 <td>Always 0</td>
 <td>0 = Player for whom spell bar is shown1 =  Vehicle creature</td>
 <td><br />
@@ -483,9 +483,9 @@ This will show or hide spells in vehicle spell bar.</td>
 <tr class="odd">
 <td>CONDITION_SOURCE_TYPE_SMART_EVENT</td>
 <td>22</td>
-<td>ID (<a href="https://trinitycore.atlassian.net/wiki/display/tc/smart_scripts#smart_scripts-id">smart_scripts.id</a>) + 1</td>
-<td>EntryOrGuid (<a href="https://trinitycore.atlassian.net/wiki/display/tc/smart_scripts#smart_scripts-entryorguid">smart_scripts.entryorguid</a>)</td>
-<td>SourceType (<a href="https://trinitycore.atlassian.net/wiki/display/tc/smart_scripts#smart_scripts-source_type">smart_scripts.source_type</a>)</td>
+<td>ID (<a href="http://www.azerothcore.org/wiki/smart_scripts#id">smart_scripts.id</a>) + 1</td>
+<td>EntryOrGuid (<a href="http://www.azerothcore.org/wiki/smart_scripts#entryorguid">smart_scripts.entryorguid</a>)</td>
+<td>SourceType (<a href="http://www.azerothcore.org/wiki/smart_scripts#source_type">smart_scripts.source_type</a>)</td>
 <td>0 = Invoker<br />
 1 = Object</td>
 <td><br />
@@ -494,8 +494,8 @@ This will show or hide spells in vehicle spell bar.</td>
 <tr class="even">
 <td>CONDITION_SOURCE_TYPE_NPC_VENDOR</td>
 <td>23</td>
-<td>vendor entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/npc_vendor#npc_vendor-entry">npc_vendor.entry</a>)</td>
-<td>item entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/npc_vendor#npc_vendor-item">npc_vendor.item</a>)</td>
+<td>vendor entry (<a href="http://www.azerothcore.org/wiki/npc_vendor#entry">npc_vendor.entry</a>)</td>
+<td>item entry (<a href="http://www.azerothcore.org/wiki/npc_vendor#item">npc_vendor.item</a>)</td>
 <td>Always 0</td>
 <td>Always 0</td>
 <td><br />
@@ -509,26 +509,6 @@ This will show or hide spells in vehicle spell bar.</td>
 <td>Always 0</td>
 <td>0 = Actor<br />
 1 = ActionTarget</td>
-<td><br />
-</td>
-</tr>
-<tr class="even">
-<td>CONDITION_SOURCE_TYPE_TERRAIN_SWAP (6.x / 7.x only)</td>
-<td>25</td>
-<td>Always 0</td>
-<td><a href="https://github.com/TrinityCore/TrinityCore/blob/6.x/src/server/game/Conditions/ConditionMgr.h#L92">terrainSwap</a> - object in terrainswap [ 6.x / 7.x only ]</td>
-<td>Always 0</td>
-<td>(source code / new description here)</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td>CONDITION_SOURCE_TYPE_PHASE (6.x / 7.x only)</td>
-<td>26</td>
-<td>Phase ID</td>
-<td>Zone or Area ID (or 0 for any area)</td>
-<td>Always 0</td>
-<td>(source code / new description here)</td>
 <td><br />
 </td>
 </tr>
@@ -590,21 +570,21 @@ Two conditions with the same SourceType, SourceGroup and SourceEntry but with a
 <tr class="even">
 <td>CONDITION_AURA</td>
 <td>1</td>
-<td>Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell">Spell.dbc</a></td>
+<td>Spell ID from <a href="http://www.azerothcore.org/wiki/Spell">Spell.dbc</a></td>
 <td>Effect index (0-2)</td>
 <td>Always 0</td>
 </tr>
 <tr class="odd">
 <td>CONDITION_ITEM</td>
 <td>2</td>
-<td>item entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/item_template#item_template-entry">item_template.entry</a>)</td>
+<td>item entry (<a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a>)</td>
 <td>item count</td>
 <td>0 = not in bank, 1 = in bank</td>
 </tr>
 <tr class="even">
 <td>CONDITION_ITEM_EQUIPPED</td>
 <td>3</td>
-<td>item entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/item_template#item_template-entry">item_template.entry</a>)</td>
+<td>item entry (<a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a>)</td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -633,7 +613,7 @@ CONDITION_REPUTATION_RANK</td>
 <br />
 <br />
 <br />
-Faction template ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Faction">Faction.dbc</a></p></td>
+Faction template ID from <a href="http://www.azerothcore.org/wiki/Faction">Faction.dbc</a></p></td>
 <td><pre><code>rank:
   1 = Hated
   2 = Hostile
@@ -656,21 +636,21 @@ Faction template ID from <a href="https://trinitycore.atlassian.net/wiki/displa
 <tr class="even">
 <td>CONDITION_SKILL</td>
 <td>7</td>
-<td>Required skill. See <a href="https://trinitycore.atlassian.net/wiki/display/tc/SkillLine">SkillLine.dbc</a> .</td>
+<td>Required skill. See <a href="http://www.azerothcore.org/wiki/SkillLine">SkillLine.dbc</a> .</td>
 <td>Skill rank value (e.g. from 1 to 450 for the 3.3.5 branch)</td>
 <td>Always 0</td>
 </tr>
 <tr class="odd">
 <td>CONDITION_QUESTREWARDED</td>
 <td>8</td>
-<td>Quest ID - see <a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">quest_template.id</a></td>
+<td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
 <tr class="even">
 <td>CONDITION_QUESTTAKEN</td>
 <td>9</td>
-<td>Quest ID - see <a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">quest_template.id</a></td>
+<td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -691,7 +671,7 @@ Faction template ID from <a href="https://trinitycore.atlassian.net/wiki/displa
 <tr class="odd">
 <td>CONDITION_ACTIVE_EVENT</td>
 <td>12</td>
-<td>Event entry (<a href="https://trinitycore.atlassian.net/wiki/display/tc/game_event#game_event-eventEntry">game_event.eventEntry</a>)</td>
+<td>Event entry (<a href="http://www.azerothcore.org/wiki/game_event#evententry">game_event.eventEntry</a>)</td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -712,7 +692,7 @@ data</strong> (see corresponding script source files for more info)</td>
 <tr class="odd">
 <td>CONDITION_QUEST_NONE</td>
 <td>14</td>
-<td>Quest ID - see <a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">quest_template.id</a></td>
+<td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -721,7 +701,7 @@ data</strong> (see corresponding script source files for more info)</td>
 CONDITION_CLASS</td>
 <td><br />
 15</td>
-<td>Class mask from <a href="https://trinitycore.atlassian.net/wiki/display/tc/ChrClasses">ChrClasses.dbc</a><br />
+<td>Class mask from <a href="http://www.azerothcore.org/wiki/ChrClasses">ChrClasses.dbc</a><br />
 Add flags together for all classes where condition is true.</td>
 <td>Always 0</td>
 <td>Always 0</td>
@@ -729,7 +709,7 @@ Add flags together for all classes where condition is true.</td>
 <tr class="odd">
 <td>CONDITION_RACE</td>
 <td>16</td>
-<td>Player must be this race. See <a href="https://trinitycore.atlassian.net/wiki/display/tc/ChrRaces">ChrRaces.dbc</a> .<br />
+<td>Player must be this race. See <a href="http://www.azerothcore.org/wiki/ChrRaces">ChrRaces.dbc</a> .<br />
 Add flags together for all races where condition is true.</td>
 <td>Always 0</td>
 <td>Always 0</td>
@@ -737,14 +717,14 @@ Add flags together for all races where condition is true.</td>
 <tr class="even">
 <td>CONDITION_ACHIEVEMENT</td>
 <td>17</td>
-<td>Achievement ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Achievement">Achievement.dbc</a></td>
+<td>Achievement ID from <a href="http://www.azerothcore.org/wiki/Achievement">Achievement.dbc</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
 <tr class="odd">
 <td>CONDITION_TITLE</td>
 <td>18</td>
-<td>Title ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/CharTitles">CharTitles.dbc</a></td>
+<td>Title ID from <a href="http://www.azerothcore.org/wiki/CharTitles">CharTitles.dbc</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -752,7 +732,7 @@ Add flags together for all races where condition is true.</td>
 <td>CONDITION_SPAWNMASK</td>
 <td>19</td>
 <td>spawnMask from<br />
-<a href="https://trinitycore.atlassian.net/wiki/display/tc/creature#creature-spawnMask">Creature.spawnMask</a> / <a href="https://trinitycore.atlassian.net/wiki/display/tc/gameobject#gameobject-spawnMask">Gameobject.spawnMask</a></td>
+<a href="http://www.azerothcore.org/wiki/creature#spawnmask">Creature.spawnMask</a> / <a href="http://www.azerothcore.org/wiki/gameobject#spawnmask">Gameobject.spawnMask</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -766,7 +746,7 @@ Add flags together for all races where condition is true.</td>
 <tr class="even">
 <td>CONDITION_UNIT_STATE</td>
 <td>21</td>
-<td>UnitState (<a href="https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Unit/Unit.h#L498">enum from Unit.h</a>)</td>
+<td>UnitState (<a href="https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Unit/Unit.h#L498">enum from Unit.h</a>)</td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -788,7 +768,7 @@ Add flags together for all races where condition is true.</td>
 <tr class="odd">
 <td>CONDITION_CREATURE_TYPE</td>
 <td>24</td>
-<td><p>Creature type from <a href="https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-type">creature_template.type</a></p>
+<td><p>Creature type from <a href="http://www.azerothcore.org/wiki/creature_template#creature_template-type">creature_template.type</a></p>
 <p>True if creature_template.type == ConditionValue1</p></td>
 <td>Always 0</td>
 <td>Always 0</td>
@@ -796,7 +776,7 @@ Add flags together for all races where condition is true.</td>
 <tr class="even">
 <td>CONDITION_SPELL</td>
 <td>25</td>
-<td>Spell ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Spell">Spell.dbc</a></td>
+<td>Spell ID from <a href="http://www.azerothcore.org/wiki/Spell">Spell.dbc</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -813,7 +793,7 @@ CONDITION_LEVEL</td>
 <td><br />
 27</td>
 <td><br />
-Player level (1-80 in 3.3.5 || 1-110 in 7.x)</td>
+Player level (1-80 in 3.3.5)</td>
 <td>Optional: 0 = Level must be equal, 1 = Level must be higher, 2 = Level must be lower,<br />
 3 = Level must be higher or equal, 4 = Level must be lower or equal.</td>
 <td>Always 0</td>
@@ -821,21 +801,21 @@ Player level (1-80 in 3.3.5 || 1-110 in 7.x)</td>
 <tr class="odd">
 <td>CONDITION_QUEST_COMPLETE</td>
 <td>28</td>
-<td>Quest ID - see <a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">quest_template.id</a></td>
+<td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
 <tr class="even">
 <td>CONDITION_NEAR_CREATURE</td>
 <td>29</td>
-<td>Creature entry from <a href="https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-entry">creature_template.entry</a></td>
+<td>Creature entry from <a href="http://www.azerothcore.org/wiki/creature_template#creature_template-entry">creature_template.entry</a></td>
 <td>Distance in yards</td>
 <td>Alive=0 / Dead=1</td>
 </tr>
 <tr class="odd">
 <td>CONDITION_NEAR_GAMEOBJECT</td>
 <td>30</td>
-<td>Gameobject entry from <a href="https://trinitycore.atlassian.net/wiki/display/tc/gameobject_template#gameobject_template-entry">gameobject_template.entry</a></td>
+<td>Gameobject entry from <a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a></td>
 <td>Distance in yards</td>
 <td>Always 0</td>
 </tr>
@@ -853,8 +833,8 @@ CONDITION_OBJECT_ENTRY_GUID</td>
 7 : TYPEID_CORPSE (player corpse, after spirit release)</p></td>
 <td><p><br />
 0 = Any object of given TypeID<br />
-if TypeID = TYPEID_UNIT =&gt; Creature entry from <a href="https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-entry">creature_template.entry<br />
-if TypeID = TYPEID_GAMEOBJECT =&gt; Gameobject entry from </a><a href="https://trinitycore.atlassian.net/wiki/display/tc/gameobject_template#gameobject_template-entry">gameobject_template.entry</a></p></td>
+if TypeID = TYPEID_UNIT =&gt; Creature entry from <a href="http://www.azerothcore.org/wiki/creature_template#creature_template-entry">creature_template.entry<br />
+if TypeID = TYPEID_GAMEOBJECT =&gt; Gameobject entry from </a><a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a></p></td>
 <td><p><br />
 0 = Any object of given type</p>
 <p>1 - 500k : creature / gameobject GUID</p></td>
@@ -1022,7 +1002,7 @@ CONDITION_HP_PCT</td>
 <tr class="even">
 <td>CONDITION_REALM_ACHIEVEMENT</td>
 <td>39</td>
-<td>Achievement ID from <a href="https://trinitycore.atlassian.net/wiki/display/tc/Achievement">Achievement.dbc</a></td>
+<td>Achievement ID from <a href="http://www.azerothcore.org/wiki/Achievement">Achievement.dbc</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -1032,13 +1012,6 @@ CONDITION_IN_WATER</td>
 <td><br />
 40</td>
 <td>Always 0 - Use NegativeCondition and the following settings:NegativeCondition = 0 If target needs to be on landNegativeCondition = 1 If target needs to be in water</td>
-<td>Always 0</td>
-<td>Always 0</td>
-</tr>
-<tr class="even">
-<td>CONDITION_TERRAIN_SWAP</td>
-<td>41</td>
-<td><p><a href="https://github.com/TrinityCore/TrinityCore/blob/6.x/src/server/game/Conditions/ConditionMgr.h#L92">terrainSwap</a> - true if object is in terrainswap <strong>[ 6.x only ]</strong></p></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -1054,7 +1027,7 @@ CONDITION_STAND_STATE</p></td>
 <tr class="even">
 <td>CONDITION_DAILY_QUEST_DONE</td>
 <td>43</td>
-<td>Quest ID - see <a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">quest_template.id</a></td>
+<td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
 <td>Always 0</td>
 <td>Always 0</td>
 </tr>
@@ -1082,7 +1055,7 @@ CONDITION_STAND_STATE</p></td>
 <tr class="even">
 <td>CONDITION_QUESTSTATE</td>
 <td>47</td>
-<td>Quest ID - see <a href="https://trinitycore.atlassian.net/wiki/display/tc/quest_template#quest_template-id">quest_template.id</a></td>
+<td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
 <td>state_mask</td>
 <td>Always 0</td>
 </tr>
@@ -1130,13 +1103,13 @@ Example: CONDITION\_AURA with NegativeCondition will be true when the player doe
 
 ### ErrorType
 
-Id from [/src/server/game/Miscellaneous/SharedDefines.h:839](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Miscellaneous/SharedDefines.h#L839). Will be displayed only for the below condition [source type](#conditions-SourceTypeOrReferenceId):
+Id from [/src/server/game/Miscellaneous/SharedDefines.h#L830](https://github.com/azerothcore/azerothcore-wotlk/blob/97e65bd4479272106bba87364d35233d2e4bd2ef/src/server/game/Miscellaneous/SharedDefines.h#L830). Will be displayed only for the below condition [source type](#conditions-SourceTypeOrReferenceId):
 
 CONDITION\_SOURCE\_TYPE\_SPELL = 17
 
 ### ErrorTextId
 
-Id from [/src/server/game/Miscellaneous/SharedDefines.h:1033](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Miscellaneous/SharedDefines.h#L1033). Will be displayed only for the below condition [source type](#conditions-SourceTypeOrReferenceId):
+Id from [/src/server/game/Miscellaneous/SharedDefines.h#L1024](https://github.com/azerothcore/azerothcore-wotlk/blob/97e65bd4479272106bba87364d35233d2e4bd2ef/src/server/game/Miscellaneous/SharedDefines.h#L1024). Will be displayed only for the below condition [source type](#conditions-SourceTypeOrReferenceId):
 
 CONDITION\_SOURCE\_TYPE\_SPELL = 17
 
@@ -1169,7 +1142,7 @@ The content of the [SourceGroup](#conditions-SourceGroup) and [SourceEntry](#con
 \***CONDITION\_SOURCE\_TYPE\_SPELL\_IMPLICIT\_TARGET = 13**
 
 -   -   SourceGroup: mask of effects to be affected by condition (1 - EFFECT\_0, 2 - EFFECT\_1, 4 - EFFECT\_2 - don't use wowhead to get number of effects, data from wowhead sometimes doesn't match real effect number)
-    -   SourceEntry: spell (Spell Id from  [Spell DBC file](Spell).)
+    -   SourceEntry: spell (Spell Id from  [Spell.dbc](Spell).)
     -   ConditionTarget:
         -   0 - Potential target of the spell
         -   1 - Caster of the spell
@@ -1183,16 +1156,16 @@ Notes:
 
 \***CONDITION\_SOURCE\_TYPE\_GOSSIP\_MENU = 14**
 
--   -   SourceGroup: gossip menu entry ([gossip\_menu.entry](gossip_menu_2130187.html#gossip_menu-entry))
-    -   SourceEntry: gossip menu text id ([gossip\_menu.text\_id](gossip_menu_2130187.html#gossip_menu-text_id))
+-   -   SourceGroup: gossip menu entry ([gossip\_menu.entry](http://www.azerothcore.org/wiki/gossip_menu#entry))
+    -   SourceEntry: gossip menu text id ([gossip\_menu.text\_id](http://www.azerothcore.org/wiki/gossip_menu#text_id))
     -   ConditionTarget:
         -   0 - Player for which gossip text is shown
         -   1 - WorldObject providing gossip
 
 \***CONDITION\_SOURCE\_TYPE\_GOSSIP\_MENU\_OPTION = 15**
 
--   -   SourceGroup: gossip menu entry ([gossip\_menu\_option.menu\_id](gossip_menu_option_2130188.html#gossip_menu_option-menu_id))
-    -   SourceEntry: gossip menu option id ([gossip\_menu\_option.id](gossip_menu_option_2130188.html#gossip_menu_option-id))
+-   -   SourceGroup: gossip menu entry ([gossip\_menu\_option.menu\_id](http://www.azerothcore.org/wiki/gossip_menu_option#menu_id))
+    -   SourceEntry: gossip menu option id ([gossip\_menu\_option.id](http://www.azerothcore.org/wiki/gossip_menu_option#id))
     -   ConditionTarget:
         -   0 - Player for which gossip text is shown
         -   1 - WorldObject providing gossip
@@ -1200,7 +1173,7 @@ Notes:
 \***CONDITION\_SOURCE\_TYPE\_CREATURE\_TEMPLATE\_VEHICLE = 16**
 
 -   -   SourceGroup: always 0
-    -   SourceEntry: creature entry ([creature\_template.entry](creature_template_2130008.html#creature_template-entry))
+    -   SourceEntry: creature entry ([creature\_template.entry](http://www.azerothcore.org/wiki/creature_template#creature_template-entry))
     -   ConditionTarget:
         -   0 - Player riding a vehicle
         -   1 - Vehicle creature
@@ -1224,8 +1197,8 @@ Notes:
 
 \***CONDITION\_SOURCE\_TYPE\_SPELL\_CLICK\_EVENT = 18**
 
--   -   SourceGroup: creature entry ([npc\_spellclick\_spells.npc\_entry](npc_spellclick_spells_2130251.html#npc_spellclick_spells-npc_entry))
-    -   SourceEntry: spell ([npc\_spellclick\_spells.spell\_id](npc_spellclick_spells_2130251.html#npc_spellclick_spells-spell_id))
+-   -   SourceGroup: creature entry ([npc\_spellclick\_spells.npc\_entry](http://www.azerothcore.org/wiki/npc_spellclick_spells#npc_entry))
+    -   SourceEntry: spell ([npc\_spellclick\_spells.spell\_id](http://www.azerothcore.org/wiki/npc_spellclick_spells#spell_id))
     -   ConditionTarget:
         -   0 - Clicker
         -   1 - Spellclick target (clickee)
@@ -1233,18 +1206,18 @@ Notes:
 \***CONDITION\_SOURCE\_TYPE\_QUEST\_ACCEPT = 19**
 
 -   -   SourceGroup: ?
-    -   SourceEntry: Quest [id](quest_template_2130261.html#quest_template-id))
+    -   SourceEntry: Quest [id](http://www.azerothcore.org/wiki/quest_template#id))
     -   ConditionTarget: always 0
 
 \***CONDITION\_SOURCE\_TYPE\_QUEST\_SHOW\_MARK = 20**
 
 -   -   SourceGroup: ?
-    -   SourceEntry: Quest [id](quest_template_2130261.html#quest_template-id))
+    -   SourceEntry: Quest [id](http://www.azerothcore.org/wiki/quest_template#id))
     -   ConditionTarget: always 0
 
 \***CONDITION\_SOURCE\_TYPE\_VEHICLE\_SPELL = 21**
 
--   -   SourceGroup: creature entry ([creature\_template.entry](creature_template_2130008.html#creature_template-entry))
+-   -   SourceGroup: creature entry ([creature\_template.entry](http://www.azerothcore.org/wiki/creature_template#creature_template-entry))
     -   SourceEntry: spell (Spell Id from [Spell.dbc](Spell))
     -   ConditionTarget:
         -   0 - Player for which spell bar is shown
@@ -1254,17 +1227,17 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_SOURCE\_TYPE\_SMART\_EVENT = 22**
 
--   -   SourceGroup: Id ([smart\_scripts.id](smart_scripts_2130108.html#smart_scripts-id)) + 1
-    -   SourceEntry: EntryOrGuid ([smart\_scripts.entryorguid](smart_scripts_2130108.html#smart_scripts-entryorguid))
-    -   SourceId: SourceType ([smart\_scripts.source\_type](smart_scripts_2130108.html#smart_scripts-source_type))
+-   -   SourceGroup: Id ([smart\_scripts.id](http://www.azerothcore.org/wiki/smart_scripts#id)) + 1
+    -   SourceEntry: EntryOrGuid ([smart\_scripts.entryorguid](http://www.azerothcore.org/wiki/smart_scripts#entryorguid))
+    -   SourceId: SourceType ([smart\_scripts.source\_type](http://www.azerothcore.org/wiki/smart_scripts#source_type))
     -   ConditionTarget:
         -   0 - Invoker
         -   1 - Object
 
 \***CONDITION\_SOURCE\_TYPE\_NPC\_VENDOR = 23**
 
--   -   SourceGroup: vendor entry ([npc\_vendor.entry](npc_vendor_2130245.html#npc_vendor-entry))
-    -   SourceEntry: item entry ([npc\_vendor.item](npc_vendor_2130245.html#npc_vendor-item))
+-   -   SourceGroup: vendor entry ([npc\_vendor.entry](http://www.azerothcore.org/wiki/npc_vendor#entry))
+    -   SourceEntry: item entry ([npc\_vendor.item](http://www.azerothcore.org/wiki/npc_vendor#item))
     -   SourceId: always 0
 
 \***CONDITION\_SOURCE\_TYPE\_SPELL\_PROC = 24**
@@ -1289,13 +1262,13 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_ITEM = 2**
 
--   -   ConditionValue1: item entry ([item\_template.entry](item_template_2130222.html#item_template-entry))
+-   -   ConditionValue1: item entry ([item\_template.entry](http://www.azerothcore.org/wiki/item_template#entry))
     -   ConditionValue2: item count
     -   ConditionValue3: in bank? (true=1)
 
 \***CONDITION\_ITEM\_EQUIPPED = 3**
 
--   -   ConditionValue1: item entry ([item\_template.entry](item_template_2130222.html#item_template-entry))
+-   -   ConditionValue1: item entry ([item\_template.entry](http://www.azerothcore.org/wiki/item_template#entry))
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1325,13 +1298,13 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_QUESTREWARDED = 8**
 
--   -   ConditionValue1: ([quest\_template.id](quest_template_2130261.html#quest_template-id))
+-   -   ConditionValue1: ([quest\_template.id](http://www.azerothcore.org/wiki/quest_template#id))
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
 \***CONDITION\_QUESTTAKEN = 9**
 
--   -   ConditionValue1: ([quest\_template.id](quest_template_2130261.html#quest_template-id))
+-   -   ConditionValue1: ([quest\_template.id](http://www.azerothcore.org/wiki/quest_template#id))
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1350,7 +1323,7 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_ACTIVE\_EVENT= 12**
 
--   -   ConditionValue1: event entry ([game\_event.eventEntry](game_event_2130151.html#game_event-eventEntry))
+-   -   ConditionValue1: event entry ([game\_event.eventEntry](http://www.azerothcore.org/wiki/game_event#evententry))
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1366,7 +1339,7 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_QUEST\_NONE = 14**
 
--   -   ConditionValue1: ([quest\_template.id](quest_template_2130261.html#quest_template-id))
+-   -   ConditionValue1: ([quest\_template.id](http://www.azerothcore.org/wiki/quest_template#id))
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1396,7 +1369,7 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_SPAWNMASK = 19**
 
--   -   ConditionValue1: spawnMask (see [Gameobject.spawnMask](gameobject_2130146.html#gameobject-spawnMask)/[Creature.spawnMask](creature_2130009.html#creature-spawnMask))
+-   -   ConditionValue1: spawnMask (see [Gameobject.spawnMask](http://www.azerothcore.org/wiki/gameobject#spawnmask)/[Creature.spawnMask](http://www.azerothcore.org/wiki/creature#spawnmask))
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1408,7 +1381,7 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_UNIT\_STATE = 21**
 
--   -   ConditionValue1: UnitState ([enum](https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Entities/Unit/Unit.h#L466)) 
+-   -   ConditionValue1: UnitState ([enum](https://github.com/azerothcore/azerothcore-wotlk/blob/97e65bd4479272106bba87364d35233d2e4bd2ef/src/server/game/Entities/Unit/Unit.h#L451)) 
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1426,7 +1399,7 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_CREATURE\_TYPE = 24**
 
--   -   ConditionValue1: Creature type ([creature\_template.type](https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-type)). Condition is true if creature\_template.type == ConditionValue1
+-   -   ConditionValue1: Creature type ([creature\_template.type](http://www.azerothcore.org/wiki/creature_template#creature_template-entry)). Condition is true if creature\_template.type == ConditionValue1
     -   ConditionValue2: always 0
     -   ConditionValue3: always 0
 
@@ -1455,7 +1428,7 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_QUEST\_COMPLETE = 28**
 
--   -   ConditionValue1: Quest [id](quest_template_2130261.html#quest_template-id)
+-   -   ConditionValue1: Quest [id](http://www.azerothcore.org/wiki/quest_template#id)
     -   ConditionValue2: Always 0
     -   ConditionValue3: always 0
 
@@ -1463,13 +1436,13 @@ Note: it will show or hide spells in vehicle spell bar.
 
 \***CONDITION\_NEAR\_CREATURE = 29**
 
--   -   ConditionValue1: Creature [entry](creature_template_2130008.html#creature_template-entry)
+-   -   ConditionValue1: Creature [entry](http://www.azerothcore.org/wiki/creature_template#creature_template-entry)
     -   ConditionValue2: Distance (yd)
     -   ConditionValue3: 0 = Alive , 1 = Dead
 
 \***CONDITION\_NEAR\_GAMEOBJECT = 30**
 
--   -   ConditionValue1: Gameobject [entry](gameobject_template_2130143.html#gameobject_template-entry)
+-   -   ConditionValue1: Gameobject [entry](http://www.azerothcore.org/wiki/gameobject_template#entry)
     -   ConditionValue2: Distance (yd)
     -   ConditionValue3: always 0
 
@@ -1482,8 +1455,8 @@ Note: it will show or hide spells in vehicle spell bar.
         -   7 - TYPEID\_CORPSE (player corpse, after released spirit)
     -   ConditionValue2: Entry
         -   0 for any object of given type
-        -   [Gameobject entry](gameobject_template_2130143.html#gameobject_template-entry) for TypeID = TYPEID\_GAMEOBJECT
-        -   [Creature entry](creature_template_2130008.html#creature_template-entry) for TypeID = TYPEID\_UNIT
+        -   [Gameobject entry](http://www.azerothcore.org/wiki/gameobject_template#entry) for TypeID = TYPEID\_GAMEOBJECT
+        -   [Creature entry](http://www.azerothcore.org/wiki/creature_template#creature_template-entry) for TypeID = TYPEID\_UNIT
     -   ConditionValue3 0 for any object of given type, any other value to match that guid
 
 \***CONDITION\_TYPE\_MASK= 32**


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change from TrinityCore links to AzerothCore wiki links.

Removed CONDITION_SOURCE_TYPE_TERRAIN_SWAP as it is for versions 6.x and 7.x only.
Removed CONDITION_SOURCE_TYPE_PHASE as it is for versions 6.x and 7.x only.
Removed CONDITION_TERRAIN_SWAP as it is for version 6.x.

**Note:**
I am unsure for the links to ErrorType and ErrorTextId that they link to the correct line.