### PR TITLE
Update waypoints and scripts documentation

### DIFF
--- a/_includes/azerothcore/sidebar.html
+++ b/_includes/azerothcore/sidebar.html
@@ -41,6 +41,7 @@
         <li><a href="/wiki/Extract-Client-Data">Extract client data (maps, mmaps, vmaps, dbc)</a></li>
         <li><a href="/wiki/linux-restarter">Linux automatic restarter</a></li>
         <li><a href="/wiki/GM-Commands">GM Commands</a></li>
+        <li><a href="/wiki/Waypoints-Information">Information about waypoints</a></li>
     </ul>
     <b>Documentation</b>
     <ul>

--- a/docs/Waypoints-Information.md
+++ b/docs/Waypoints-Information.md
@@ -1,0 +1,105 @@
+### Different kinds of waypoint paths
+
+- Waypoint paths directly attached to a creature via [creature_addon.path_id](creature_addon#path_id) use the tables [waypoint_data](waypoint_data) and [waypoint_scripts](waypoint_scripts). They can be added and manipulated using the GM '.wp' commands.
+- [SmartAI](smart_scripts) uses waypoint paths defined in table [waypoints](waypoints).
+- The table [script_waypoint](script_waypoint) contains waypoint paths for [CreatureAI](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/AI/ScriptedAI/ScriptedCreature.h#L159).
+
+### Overview of GM '.wp' commands
+
+- ```.wp add``` [waypoint_data.id](waypoint_data#id): Add a new point for the specified path id. It is recommended to use creature GUID * 10 or GUID * 100 as path id, but it can be any random number.
+- ```.wp reload``` [waypoint_data.id](waypoint_data#id): Reload the specified path id (for new paths has to be executed before ```.wp load```).
+- ```.wp load``` [waypoint_data.id](waypoint_data#id): Load the specified path id for the selected creature.
+- ```.wp unload```: Unload the path of the selected creature.
+- ```.wp show on``` [waypoint_data.id](waypoint_data#id): Show all waypoints of the specified path (GM on is required to actually see them). If no path id is specified shows the waypoints of the selected creature.
+- ```.wp show off```: Hide all visual waypoints.
+- ```.wp show info```: Show information about the selected waypoint.
+- ```.wp modify```: Modify the selected waypoint, options:
+  - ```del```: Delete the selected waypoint.
+  - ```move```: Move the selected waypoint to the position of the GM.
+  - ```delay```: Change the [delay](waypoint_data#delay) of the selected waypoint.
+  - ```action```: Change the [action](scripts#id) of the selected waypoint.
+  - ```action_chance```: Change the [action_chance](waypoint_data#action_chance) of the selected waypoint.
+  - ```move_type```: Change the [move_type](waypoint_data#move_type) of the selected waypoint (0: walk, 1: run, 2: fly).
+- ```.wp event```: Modify the waypoint [actions](scripts#id), options:
+  - ```add``` [guid](scripts#guid): Add a new action with the specified GUID (not to be confused with the creature GUID!). If no GUID is specified a new one is generated automatically.
+  - ```listid``` [action](scripts#id): Show information about the specified action id.
+  - ```del``` [guid](scripts#guid): Delete the action with the specified GUID.
+  - ```mod``` [guid](scripts#guid): Modify the action with the specified GUID, further options:
+    - ```setid``` [action](scripts#id): Set a new action id.
+    - ```delay``` [delay](scripts#delay): Set a specific delay before the script activates.
+    - ```command``` [command](scripts#command): Set the command for this script.
+    - ```datalong``` [datalong](scripts#datalong): Set the datalong for this script.
+    - ```datalong2``` [datalong2](scripts#datalong2): Set the datalong2 for this script.
+    - ```dataint``` [dataint](scripts#dataint): Set the dataint for this script.
+    - ```posx``` [posx](scripts#posx): Set the posx for this script.
+    - ```posy``` [posy](scripts#posy): Set the posy for this script.
+    - ```posz``` [posz](scripts#posz): Set the posz for this script.
+    - ```orientation``` [orientation](scripts#orientation): Set the orientation for this script.
+
+### Example for path creation using GM '.wp' commands
+
+Example creature GUID: 1234567, example path id: 123456700
+
+- Create a macro 'wp1' with this command:
+  ```
+  .wp add 123456700
+  ```
+- Create a macro 'wp2' with these commands:
+  ```
+  .wp reload 123456700
+  .wp load 123456700
+  ```
+- Create a macro 'wp3' with this command:
+  ```
+  .wp show on 123456700
+  ```
+- Create a macro 'wp4' with this command:
+  ```
+  .wp show off 123456700
+  ```
+- Teleport to the creature:
+  ```
+  .go creature 1234567
+  ```
+- Use macro 'wp1'
+- Create the path:
+  - Go to the position where the next waypoint should be and use macro 'wp1'
+  - repeat until all waypoints are set (don't forget to also create a path back to the starting position)
+  - use macros 'wp3' and 'wp4' to show / hide the path (GM on required to actually see the path)
+  - ensure that the waypoints are not too far away from each other, especially if the creature is walking over hills etc. as it will try to directly move to the next waypoint, even if this means going through the ground
+- Select the creature and use macro 'wp2'; it should now start moving
+
+### A few helpful SQL statements
+
+#### Delete path
+
+- Select the creature, then unload the path:
+  ```
+  .wp unload
+  ```
+
+- Delete the path from the DB, for example 123456700:
+  ```sql
+  DELETE FROM `waypoint_data` WHERE `id` = 123456700;
+  ```
+
+#### Take over the waypoints from 'waypoint_data' to 'waypoints' (SmartAI)
+
+If you need the waypoints for SmartAI you have to copy the waypoints from table [waypoint_data](waypoint_data) into table [waypoints](waypoints) and then delete the original waypoints (unload the path for the creature via ```.wp unload``` if it was loaded before). Here an example for path 123456700:
+```sql
+INSERT INTO `waypoints` (`entry`,`pointid`,`position_x`,`position_y`,`position_z`)
+  SELECT `id`,`point`,`position_x`,`position_y`,`position_z` FROM `waypoint_data` WHERE `id` = 123456700;
+DELETE FROM `waypoint_data` WHERE `id` = 123456700;
+```
+
+#### Take over the waypoints from 'waypoint_data' to 'script_waypoint' (CreatureAI)
+
+The same as above, but now for [script_waypoint](script_waypoint) instead of [waypoints](waypoints). The entry of [script_waypoint](script_waypoint) has to be the [creature_template.entry](creature_template#entry), here for example 1234567:
+```sql
+INSERT INTO `script_waypoint` (`entry`,`pointid`,`location_x`,`location_y`,`location_z`)
+  SELECT 1234567 AS `entry`,`point`,`position_x`,`position_y`,`position_z` FROM `waypoint_data` WHERE `id` = 123456700;
+DELETE FROM `waypoint_data` WHERE `id` = 123456700;
+
+```
+Don't forget to unload the path from the creature if it was loaded before.
+

--- a/docs/event_scripts.md
+++ b/docs/event_scripts.md
@@ -1,14 +1,23 @@
 [Database Structure](Database-Structure) > [World-Database](World-Database) > [event_scripts](event_scripts)
 
-Column | Type | Description
---- | --- | ---
-Id | mediumint(8) unsigned | 
-Delay | int(10) unsigned | 
-Command | mediumint(8) unsigned | 
-Datalong | mediumint(8) unsigned | 
-Datalong2 | int(10) unsigned | 
-Dataint | int(11) | 
-X | float | 
-Y | float | 
-Z | float | 
-O | float | 
+# event\_scripts
+
+### Information
+
+Holds scripts activated whenever an event is activated, be it by an object or as the spell effect SPELL\_EFFECT\_SEND\_EVENT (61).
+
+### Structure
+
+| Field                            | Type         | Attributes   | Key | Null | Default |
+|----------------------------------|--------------|--------------|-----|------|---------|
+| [id](scripts#id)                 | mediumint(8) | unsigned     |     | NO   | 0       |
+| [delay](scripts#delay)           | int(10)      | unsigned     |     | NO   | 0       |
+| [command](scripts#command)       | mediumint(8) | unsigned     |     | NO   | 0       |
+| [datalong](scripts#otherfields)  | mediumint(8) | unsigned     |     | NO   | 0       |
+| [datalong2](scripts#otherfields) | int(10)      | unsigned     |     | NO   | 0       |
+| [dataint](scripts#otherfields)   | int(11)      |              |     | NO   | 0       |
+| [x](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [y](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [z](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [o](scripts#otherfields)         | float        |              |     | NO   | 0       |
+

--- a/docs/script_waypoint.md
+++ b/docs/script_waypoint.md
@@ -1,134 +1,50 @@
+[Database Structure](Database-Structure) > [World-Database](World-Database) > [script_waypoint](script_waypoint)
+
 # script\_waypoint
 
-[<-Back-to:World](database-world.md)
+###### **Used by [CreatureAI](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/AI/ScriptedAI/ScriptedCreature.h#L159)**
 
-**The \`script\_waypoint\` table**
+### Information
 
-`table-no-description`
+Used for CreatureAI waypoint movement. See also [Waypoints-Information](Waypoints-Information) for general information about waypoints.
 
-**Structure**
+### Structure
 
-<table>
-<colgroup>
-<col width="12%" />
-<col width="12%" />
-<col width="12%" />
-<col width="12%" />
-<col width="12%" />
-<col width="12%" />
-<col width="12%" />
-<col width="12%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td><p><strong>Field</strong></p></td>
-<td><p><strong>Type</strong></p></td>
-<td><p><strong>Attributes</strong></p></td>
-<td><p><strong>Key</strong></p></td>
-<td><p><strong>Null</strong></p></td>
-<td><p><strong>Default</strong></p></td>
-<td><p><strong>Extra</strong></p></td>
-<td><p><strong>Comment</strong></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="#entry">entry</a></p></td>
-<td><p>mediumint(8)</p></td>
-<td><p>unsigned</p></td>
-<td><p>PRI</p></td>
-<td><p>NO</p></td>
-<td><p>0</p></td>
-<td><p> </p></td>
-<td><p>creature_template entry</p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="#point_id">point_id</a></p></td>
-<td><p>mediumint(8)</p></td>
-<td><p>unsigned</p></td>
-<td><p>PRI</p></td>
-<td><p>NO</p></td>
-<td><p>0</p></td>
-<td><p> </p></td>
-<td><p> </p></td>
-</tr>
-<tr class="even">
-<td><p><a href="#location_x">location_x</a></p></td>
-<td><p>float</p></td>
-<td><p>signed</p></td>
-<td><p> </p></td>
-<td><p>NO</p></td>
-<td><p>0</p></td>
-<td><p> </p></td>
-<td><p> </p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="#location_y">location_y</a></p></td>
-<td><p>float</p></td>
-<td><p>signed</p></td>
-<td><p> </p></td>
-<td><p>NO</p></td>
-<td><p>0</p></td>
-<td><p> </p></td>
-<td><p> </p></td>
-</tr>
-<tr class="even">
-<td><p><a href="#location_z">location_z</a></p></td>
-<td><p>float</p></td>
-<td><p>signed</p></td>
-<td><p> </p></td>
-<td><p>NO</p></td>
-<td><p>0</p></td>
-<td><p> </p></td>
-<td><p> </p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="#waittime">waittime</a></p></td>
-<td><p>int(10)</p></td>
-<td><p>unsigned</p></td>
-<td><p> </p></td>
-<td><p>NO</p></td>
-<td><p>0</p></td>
-<td><p> </p></td>
-<td><p> </p></td>
-</tr>
-<tr class="even">
-<td><p><a href="#point_comment">point_comment</a></p></td>
-<td><p>text</p></td>
-<td><p>signed</p></td>
-<td><p> </p></td>
-<td><p>YES</p></td>
-<td><p>NULL</p></td>
-<td><p> </p></td>
-<td><p>waittime in millisecs</p></td>
-</tr>
-</tbody>
-</table>
-
-**Description of the fields**
+| Field                            | Type         | Attributes | Key | Null | Default |
+|----------------------------------|--------------|------------|-----|------|---------|
+| [entry](creature_template#entry) | mediumint(8) | unsigned   | PRI | NO   | 0       |
+| [pointid](#pointid)              | mediumint(8) | unsigned   | PRI | NO   | 0       |
+| [location_x](#location_x)        | float        |            |     | NO   | 0       |
+| [location_y](#location_y)        | float        |            |     | NO   | 0       |
+| [location_z](#location_z)        | float        |            |     | NO   | 0       |
+| [waittime](#waittime)            | int(10)      | unsigned   |     | NO   | 0       |
+| [point_comment](#point_comment)  | text         |            |     | YES  | NULL    |
 
 ### entry
 
-`field-no-description|1`
+Entry of the creature, see [creature\_template.entry](creature_template#entry).
 
 ### pointid
 
-`field-no-description|2`
+Unique ID for each waypoint. Starts at 1 and increases with each waypoint.
 
 ### location\_x
 
-`field-no-description|3`
+The X coordinate of the destination waypoint.
 
 ### location\_y
 
-`field-no-description|4`
+The Y coordinate of the destination waypoint.
 
 ### location\_z
 
-`field-no-description|5`
+The Z coordinate of the destination waypoint.
 
 ### waittime
 
-`field-no-description|6`
+Wait time in milliseconds.
 
 ### point\_comment
 
-`field-no-description|7`
+Text comment.
+

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,203 +1,45 @@
-# scripts
+[Database Structure](Database-Structure) > [World-Database](World-Database) > [scripts](scripts)
 
-[<-Back-to:World](database-world.md)
+# scripts
 
 # Tables: \*\*\*\_scripts
 
 This table format is used for 3 different tables to control possible scripts activated by different actions:
 
-**spell\_scripts:** Holds scripts that can be activated by spells with effect SPELL\_EFFECT\_SCRIPT\_EFFECT (77) or SPELL\_EFFECT\_DUMMY(3).
+**[spell\_scripts](spell_scripts):** Holds scripts that can be activated by spells with effect SPELL\_EFFECT\_SCRIPT\_EFFECT (77) or SPELL\_EFFECT\_DUMMY(3).
 
-**event\_scripts:** Holds scripts activated whenever an event is activated, be it by an object or as the spell effect SPELL\_EFFECT\_SEND\_EVENT (61).
+**[event\_scripts](event_scripts):** Holds scripts activated whenever an event is activated, be it by an object or as the spell effect SPELL\_EFFECT\_SEND\_EVENT (61).
 
-**waypoint\_scripts:** Holds scripts used in the [waypoint\_data](waypoint_data) table.
+**[waypoint\_scripts](waypoint_scripts):** Holds scripts used in the [waypoint\_data](waypoint_data) table. See also [Waypoints-Information](Waypoints-Information) for general information about waypoints.
 
 NOTE: An entry in this table may have more than one row as a script may do more than just one action. Also each action the script may make can have a separate delay attached to it. In that case, the core will activate the appropriate action after the correct delay.
 
 ## **Structure**
 
-<table>
-<tbody>
-<tr class="odd">
-<td><strong>Field</strong></td>
-<td><strong>Type</strong></td>
-<td><strong>Attributes</strong></td>
-<td><strong>Key</strong></td>
-<td><strong>Null</strong></td>
-<td><strong>Default</strong></td>
-<td><strong>Extra</strong></td>
-<td><strong>Comment</strong></td>
-</tr>
-<tr class="even">
-<td><a href="#id">id</a></td>
-<td>mediumint(8)</td>
-<td>unsigned</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td><a href="#effindex">effIndex</a> <sup>[1]</sup></td>
-<td>tinyint(3)</td>
-<td>unsigned</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="even">
-<td><a href="#delay">delay</a></td>
-<td>int(10)</td>
-<td>unsigned</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td><a href="#command">command</a></td>
-<td>mediumint(8)</td>
-<td>unsigned</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="even">
-<td><a href="#datalong">datalong</a></td>
-<td>mediumint(8)</td>
-<td>unsigned</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td><a href="#datalong2">datalong2</a></td>
-<td>int(10)</td>
-<td>unsigned</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="even">
-<td><a href="#otherfields">dataint</a></td>
-<td>int(11)</td>
-<td>signed</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td><a href="#otherfields">x</a></td>
-<td>float</td>
-<td>signed</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="even">
-<td><a href="#otherfields">y</a></td>
-<td>float</td>
-<td>signed</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td><a href="#otherfields">z</a></td>
-<td>float</td>
-<td>signed</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="even">
-<td><a href="#otherfields">o</a></td>
-<td>float</td>
-<td>signed</td>
-<td><br />
-</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-<tr class="odd">
-<td><a href="#guid">guid</a> <sup>[2]</sup></td>
-<td>int(11)</td>
-<td>signed</td>
-<td>PRI</td>
-<td>NO</td>
-<td>0</td>
-<td><br />
-</td>
-<td><br />
-</td>
-</tr>
-</tbody>
-</table>
-
-<sup>1</sup> present in spell\_scripts table only. 
-<sup>2</sup> present in waypoint\_scripts table only.
+| Field                     | Comment
+|---------------------------|--------
+| [id](#id)                 |
+| [effIndex](#effindex)     | only used in [spell\_scripts](spell_scripts)
+| [delay](#delay)           |
+| [command](#command)       |
+| [datalong](#otherfields)  |
+| [datalong2](#otherfields) |
+| [dataint](#otherfields)   |
+| [x](#otherfields)         |
+| [y](#otherfields)         |
+| [z](#otherfields)         |
+| [o](#otherfields)         |
+| [guid](#guid)             | only used in [waypoint\_scripts](waypoint_scripts); acts as primary key and is set automatically using the [GM command](GM-Commands) 'wp event add'
 
 ## **Description of the fields**
 
 ### id
 
-For **spell\_scripts**, it is the spell ID. See [Spell.dbc](https://trinitycore.atlassian.net/wiki/display/tc/Spell)
+For **spell\_scripts**, it is the spell ID. See [Spell.dbc](Spell)
 
 For **event\_scripts**, it is the event ID. There doesn't exist currently a full list of events. In any case, the event IDs are taken directly from gameobject WDB data or spell effect data. If both a gameobject and a spell activate the same event, the IDs will match.
 
-For **waypoint\_scripts**, it is the [action](waypoint_data_2130114.html#waypoint_data-action) ID.
+For **waypoint\_scripts**, it is the [action](waypoint_data#action) ID.
 
 ### effIndex
 
@@ -209,236 +51,234 @@ Delay in seconds before this current step of the script activates. 0 = instant.
 
 ### command
 
-The type of action performed by the script after [delay](#scripts-delay) seconds have passed. The value of this field affects what other fields also need to be set. The following commands can be used:
+The type of action performed by the script after [delay](#delay) seconds have passed. The value of this field affects what other fields also need to be set. The following commands can be used:
 
-| Command | Name                   | Description                                                              |
-|---------|------------------------|--------------------------------------------------------------------------|
-| 0       | TALK                   | Creature say/whisper/yell/textemote.                                     |
-| 1       | EMOTE                  | Play emote on creature.                                                  |
-| 2       | FIELD\_SET             | Change the value at an index for the player.                             |
-| 3       | MOVE\_TO               | Relocate creature to a destination.                                      |
-| 4       | FLAG\_SET              | Turns on bits on a flag field at an index for the player.                |
-| 5       | FLAG\_REMOVE           | Turns off bits on a flag field at an index for the player.               |
-| 6       | TELEPORT\_TO           | Teleports the player to a location.                                      |
-| 7       | QUEST\_EXPLORED        | Satisfies the explore requirement for a quest.                           |
-| 8       | KILL\_CREDIT           | Gives kill credit to the player.                                         |
-| 9       | RESPAWN\_GAMEOBJECT    | Spawns a despawned gameobject.                                           |
-| 10      | TEMP\_SUMMON\_CREATURE | Temporarily summons a creature.                                          |
-| 11      | OPEN\_DOOR             | Opens a door gameobject (type h1. 0).                                    |
-| 12      | CLOSE\_DOOR            | Closes a door gameobject (type 0).                                       |
-| 13      | ACTIVATE\_OBJECT       | Activates an object.                                                     |
-| 14      | REMOVE\_AURA           | Removes an aura due to a spell.                                          |
-| 15      | CAST\_SPELL            | Casts a spell.                                                           |
-| 16      | PLAY\_SOUND            | Plays a sound.                                                           |
-| 17      | CREATE\_ITEM           | Creates specified amount of items for the player.                        |
-| 18      | DESPAWN\_SELF          | Forces creature to despawn.                                              |
-| 19      | nuttin                 | There is no command 19.                                                  |
-| 20      | LOAD\_PATH             | Load path to unit, then unit starts waypoint movement.                   |
-| 21      | CALLSCRIPT\_TO\_UNIT   | Calls script from one of \*\_scripts table with given unit as source.    |
-| 22      | KILL                   | Changes state of the creature to dead and optionally removes its corpse. |
-| 30      | ORIENTATION            | Changes unit's orientation (Used in Waypoint Scripts)                    |
-| 31      | EQUIP                  | Sets creature equipment.                                                 |
-| 32      | MODEL                  | Sets creature model.                                                     |
-| 33      | CLOSE\_GOSSIP          | Closes gossip window. This command is only used for Gossip Scripts.      |
-| 34      | PLAYMOVIE              | Plays movie.                                                             |
-| 35      | MOVEMENT               | Change movement type.                                                    |
+| Command | Name                                                               | Description                                                              |
+|---------|--------------------------------------------------------------------|--------------------------------------------------------------------------|
+| 0       | [TALK](#script_command_talk--0)                                    | Creature say/whisper/yell/textemote.                                     |
+| 1       | [EMOTE](#script_command_emote--1)                                  | Play emote on creature.                                                  |
+| 2       | [FIELD\_SET](#script_command_field_set--2)                         | Change the value at an index for the player.                             |
+| 3       | [MOVE\_TO](#script_command_move_to--3)                             | Relocate creature to a destination.                                      |
+| 4       | [FLAG\_SET](#script_command_flag_set--4)                           | Turns on bits on a flag field at an index for the player.                |
+| 5       | [FLAG\_REMOVE](#script_command_flag_remove--5)                     | Turns off bits on a flag field at an index for the player.               |
+| 6       | [TELEPORT\_TO](#script_command_teleport_to--6)                     | Teleports the player to a location.                                      |
+| 7       | [QUEST\_EXPLORED](#script_command_quest_explored--7)               | Satisfies the explore requirement for a quest.                           |
+| 8       | [KILL\_CREDIT](#script_command_kill_credit--8)                     | Gives kill credit to the player.                                         |
+| 9       | [RESPAWN\_GAMEOBJECT](#script_command_respawn_gameobject--9)       | Spawns a despawned gameobject.                                           |
+| 10      | [TEMP\_SUMMON\_CREATURE](#script_command_temp_summon_creature--10) | Temporarily summons a creature.                                          |
+| 11      | [OPEN\_DOOR](#script_command_open_door--11)                        | Opens a door gameobject (type h1. 0).                                    |
+| 12      | [CLOSE\_DOOR](#script_command_close_door--12)                      | Closes a door gameobject (type 0).                                       |
+| 13      | [ACTIVATE\_OBJECT](#script_command_activate_object--13)            | Activates an object.                                                     |
+| 14      | [REMOVE\_AURA](#script_command_remove_aura--14)                    | Removes an aura due to a spell.                                          |
+| 15      | [CAST\_SPELL](#script_command_cast_spell--15)                      | Casts a spell.                                                           |
+| 16      | [PLAY\_SOUND](#script_command_play_sound--16)                      | Plays a sound.                                                           |
+| 17      | [CREATE\_ITEM](#script_command_create_item--17)                    | Creates specified amount of items for the player.                        |
+| 18      | [DESPAWN\_SELF](#script_command_despawn_self--18)                  | Forces creature to despawn.                                              |
+| 20      | [LOAD\_PATH](#script_command_load_path--20)                        | Load path to unit, then unit starts waypoint movement.                   |
+| 21      | [CALLSCRIPT\_TO\_UNIT](#script_command_callscript_to_unit--21)     | Calls script from one of \*\_scripts table with given unit as source.    |
+| 22      | [KILL](#script_command_kill--22)                                   | Changes state of the creature to dead and optionally removes its corpse. |
+| 30      | [ORIENTATION](#script_command_orientation--30)                     | Changes unit's orientation (Used in Waypoint Scripts)                    |
+| 31      | [EQUIP](#script_command_equip--31)                                 | Sets creature equipment.                                                 |
+| 32      | [MODEL](#script_command_model--32)                                 | Sets creature model.                                                     |
+| 33      | [CLOSE\_GOSSIP](#script_command_close_gossip--33)                  | Closes gossip window. This command is only used for Gossip Scripts.      |
+| 34      | [PLAYMOVIE](#script_command_playmovie--34)                         | Plays movie.                                                             |
+| 35      | [MOVEMENT](#script_command_movement--35)                           | Change movement type.                                                    |
 
 ### OtherFields
 
 Depending on what command was used, the meaning and use for the following fields varies.
 
-\***SCRIPT\_COMMAND\_TALK = 0**
+#### \*SCRIPT\_COMMAND\_TALK = 0
 
--   -   source: Creature.
-    -   target: any/Player (for whisper).
-    -   datalong: 0=say, 1=yell, 2=text emote, 3=boss emote, 4=whisper 5=boss whisper
-    -   dataint: reference to [broadcast\_text.id](broadcast_text)
+- source: Creature.
+- target: any/Player (for whisper).
+- datalong: 0=say, 1=yell, 2=text emote, 3=boss emote, 4=whisper 5=boss whisper
+- dataint: reference to [broadcast\_text.id](broadcast_text)
 
-\***SCRIPT\_COMMAND\_EMOTE = 1**
+#### \*SCRIPT\_COMMAND\_EMOTE = 1
 
--   -   source or target: Creature.
-    -   datalong: The emote ID to play.
-    -   datalong2: If this value is &gt; 0 the npc will play emote state rather than oneshot.
+- source or target: Creature.
+- datalong: The emote ID to play.
+- datalong2: If this value is &gt; 0 the npc will play emote state rather than oneshot.
 
-\***SCRIPT\_COMMAND\_FIELD\_SET = 2**
+#### \*SCRIPT\_COMMAND\_FIELD\_SET = 2
 
--   -   source or target: Creature.
-    -   datalong: Index of the field.
-    -   datalong2: Value to place at the index.
+- source or target: Creature.
+- datalong: Index of the field.
+- datalong2: Value to place at the index.
 
-\***SCRIPT\_COMMAND\_MOVE\_TO = 3**
+#### \*SCRIPT\_COMMAND\_MOVE\_TO = 3
 
--   -   source: Creature.
-    -   datalong2: Length (in time) of the motion.
-    -   x: X position to move to.
-    -   y: Y position to move to.
-    -   z: Z position to move to.
+- source: Creature.
+- datalong2: Length (in time) of the motion.
+- x: X position to move to.
+- y: Y position to move to.
+- z: Z position to move to.
 
-\***SCRIPT\_COMMAND\_FLAG\_SET = 4**
+#### \*SCRIPT\_COMMAND\_FLAG\_SET = 4
 
--   -   source or target: Creature.
-    -   datalong: Field index to be set.
-    -   datalong2: Flag bit(s) to set.
+- source or target: Creature.
+- datalong: Field index to be set.
+- datalong2: Flag bit(s) to set.
 
-\***SCRIPT\_COMMAND\_FLAG\_REMOVE = 5**
+#### \*SCRIPT\_COMMAND\_FLAG\_REMOVE = 5
 
--   -   source or target: Creature.
-    -   datalong: Field index to be unset.
-    -   datalong2: Flag bit(s) to unset.
+- source or target: Creature.
+- datalong: Field index to be unset.
+- datalong2: Flag bit(s) to unset.
 
-\***SCRIPT\_COMMAND\_TELEPORT\_TO = 6**
+#### \*SCRIPT\_COMMAND\_TELEPORT\_TO = 6
 
--   -   source or target: Player (datalong2 0) or Creature (datalong2 1).
-    -   datalong: Target Map ID. See [Map.dbc](https://trinitycore.atlassian.net/wiki/display/tc/Map)
-    -   x: Teleport target x coordinate.
-    -   y: Teleport target y coordinate.
-    -   z: Teleport target z coordinate.
-    -   o: Teleport target orientation.
+- source or target: Player (datalong2 0) or Creature (datalong2 1).
+- datalong: Target Map ID. See [Map.dbc](Map)
+- x: Teleport target x coordinate.
+- y: Teleport target y coordinate.
+- z: Teleport target z coordinate.
+- o: Teleport target orientation.
 
-\***SCRIPT\_COMMAND\_QUEST\_EXPLORED = 7**
+#### \*SCRIPT\_COMMAND\_QUEST\_EXPLORED = 7
 
--   -   source or target: Player.
-    -   target or source: WorldObject.
-    -   datalong: Quest entry which external status should be satisfied. See [quest\_template.entry](quest_template_2130261.html#quest_template-entry).
-    -   datalong2: Distance away from the NPC/object that the player can be and have the script still take effect (min value 5).
+- source or target: Player.
+- target or source: WorldObject.
+- datalong: Quest entry which external status should be satisfied. See [quest\_template.id](quest_template#id).
+- datalong2: Distance away from the NPC/object that the player can be and have the script still take effect (min value 5).
 
-\***SCRIPT\_COMMAND\_KILL\_CREDIT = 8**
+#### \*SCRIPT\_COMMAND\_KILL\_CREDIT = 8
 
--   -   target or source: Player.
-    -   datalong: Creatue entry of kill credit. See [creature\_template.entry](creature_template_2130008.html#creature_template-entry).
-    -   datalong2: If value &gt; 0 gives kill credit to the whole group player belongs to, otherwise, gives personal kill credit.
+- target or source: Player.
+- datalong: Creatue entry of kill credit. See [creature\_template.entry](creature_template#entry).
+- datalong2: If value &gt; 0 gives kill credit to the whole group player belongs to, otherwise, gives personal kill credit.
 
-\***SCRIPT\_COMMAND\_RESPAWN\_GAMEOBJECT = 9**
+#### \*SCRIPT\_COMMAND\_RESPAWN\_GAMEOBJECT = 9
 
--   -   source: WorldObject (summoner).
-    -   datalong: Guid of the gameobject to respawn. See [gameobject.guid](gameobject_2130146.html#gameobject-guid).
-    -   datalong2: Despawn time in seconds. If the value is &lt; 5 seconds: 5 is used instead.
+- source: WorldObject (summoner).
+- datalong: Guid of the gameobject to respawn. See [gameobject.guid](gameobject#guid).
+- datalong2: Despawn time in seconds. If the value is &lt; 5 seconds: 5 is used instead.
 
-\***SCRIPT\_COMMAND\_TEMP\_SUMMON\_CREATURE = 10**
+#### \*SCRIPT\_COMMAND\_TEMP\_SUMMON\_CREATURE = 10
 
--   -   source: WorldObject (summoner).
-    -   datalong: Entry of the summoned creature. See [creature\_template.entry](creature_template_2130008.html#creature_template-entry).
-    -   datalong2: Despawn time in ms.
-    -   x: Summon target x coordinate.
-    -   y: Summon target y coordinate.
-    -   z: Summon target z coordinate.
-    -   o: Summon target orientation.
+- source: WorldObject (summoner).
+- datalong: Entry of the summoned creature. See [creature\_template.entry](creature_template#entry).
+- datalong2: Despawn time in ms.
+- x: Summon target x coordinate.
+- y: Summon target y coordinate.
+- z: Summon target z coordinate.
+- o: Summon target orientation.
 
-\***SCRIPT\_COMMAND\_OPEN\_DOOR = 11**
+#### \*SCRIPT\_COMMAND\_OPEN\_DOOR = 11
 
--   -   source: WorldObject.
-    -   datalong: Guid of the activated door. See [gameobject.guid](gameobject_2130146.html#gameobject-guid).
-    -   datalong2: Delay before closing again the door. If the value is &lt; 15 seconds: 15 is used instead.
+- source: WorldObject.
+- datalong: Guid of the activated door. See [gameobject.guid](gameobject#guid).
+- datalong2: Delay before closing again the door. If the value is &lt; 15 seconds: 15 is used instead.
 
-\***SCRIPT\_COMMAND\_CLOSE\_DOOR = 12**
+#### \*SCRIPT\_COMMAND\_CLOSE\_DOOR = 12
 
--   -   source: WorldObject.
-    -   datalong: Guid of the activated door. See [gameobject.guid](gameobject_2130146.html#gameobject-guid).
-    -   datalong2: Delay before opening again the door. If the value is &lt; 15 seconds: 15 is used instead.
+- source: WorldObject.
+- datalong: Guid of the activated door. See [gameobject.guid](gameobject#guid).
+- datalong2: Delay before opening again the door. If the value is &lt; 15 seconds: 15 is used instead.
 
-\***SCRIPT\_COMMAND\_ACTIVATE\_OBJECT = 13**
+#### \*SCRIPT\_COMMAND\_ACTIVATE\_OBJECT = 13
 
--   -   source: Unit.
-    -   target: GameObject.
+- source: Unit.
+- target: GameObject.
 
-\***SCRIPT\_COMMAND\_REMOVE\_AURA = 14**
+#### \*SCRIPT\_COMMAND\_REMOVE\_AURA = 14
 
--   -   source (datalong2 != 0) or target (datalong2 h1. 0): Unit.
-    -   datalong: Spell ID. See [Spell.dbc](https://trinitycore.atlassian.net/wiki/display/tc/Spell)
-    -   datalong2: If value &gt; 0, then remove from the source; otherwise remove from the target.
+- source (datalong2 != 0) or target (datalong2 h1. 0): Unit.
+- datalong: Spell ID. See [Spell.dbc](Spell)
+- datalong2: If value &gt; 0, then remove from the source; otherwise remove from the target.
 
-\***SCRIPT\_COMMAND\_CAST\_SPELL = 15**
+#### \*SCRIPT\_COMMAND\_CAST\_SPELL = 15
 
--   -   source: Unit.
-    -   target: Unit.
-    -   datalong: Spell ID. See [Spell.dbc](https://trinitycore.atlassian.net/wiki/display/tc/Spell)
-    -   datalong2:
-        -   0 - Source-&gt;Target
-        -   1 - Source-&gt;Source (Self cast, use for dummy spells)
-        -   2 - Target-&gt;Target
-        -   3 - Target-&gt;Source
-        -   4 - Source-&gt;Closest entry of dataint.
-    -   dataint: Creature entry to target if datalong2 value is 4, or triggered attribute for CastSpell method in other cases.
-    -   x: Search range for creature entry (dataint) if datalong2 value is 4.
+- source: Unit.
+- target: Unit.
+- datalong: Spell ID. See [Spell.dbc](Spell)
+- datalong2:
+  - 0 - Source-&gt;Target
+  - 1 - Source-&gt;Source (Self cast, use for dummy spells)
+  - 2 - Target-&gt;Target
+  - 3 - Target-&gt;Source
+  - 4 - Source-&gt;Closest entry of dataint.
+- dataint: Creature entry to target if datalong2 value is 4, or triggered attribute for CastSpell method in other cases.
+- x: Search range for creature entry (dataint) if datalong2 value is 4.
 
-\***SCRIPT\_COMMAND\_PLAY\_SOUND = 16**
+#### \*SCRIPT\_COMMAND\_PLAY\_SOUND = 16
 
--   -   source: WorldObject.
-    -   target: none (datalong2 & 1 0) or Player (datalong2 & 1 != 0).
-    -   datalong: Sound ID.
-    -   datalong2:
-        -   0 - play direct sound to everyone.
-        -   1 - play direct sound to target (must be Player).
-        -   2 - play sound with distance dependency to anyone.
-        -   3 - play sound with distance dependency to target (must be Player).
+- source: WorldObject.
+- target: none (datalong2 & 1 0) or Player (datalong2 & 1 != 0).
+- datalong: Sound ID.
+- datalong2:
+  - 0 - play direct sound to everyone.
+  - 1 - play direct sound to target (must be Player).
+  - 2 - play sound with distance dependency to anyone.
+  - 3 - play sound with distance dependency to target (must be Player).
 
-\***SCRIPT\_COMMAND\_CREATE\_ITEM = 17**
+#### \*SCRIPT\_COMMAND\_CREATE\_ITEM = 17
 
--   -   target or source: Player.
-    -   datalong: Item entry to create. See [item\_template.entry](item_template_2130222.html#item_template-entry).
-    -   datalong2: Amount of items to create.
+- target or source: Player.
+- datalong: Item entry to create. See [item\_template.entry](item_template#entry).
+- datalong2: Amount of items to create.
 
-\***SCRIPT\_COMMAND\_DESPAWN\_SELF = 18**
+#### \*SCRIPT\_COMMAND\_DESPAWN\_SELF = 18
 
--   -   target: Creature.
-    -   datalong: Despawn delay.
+- target: Creature.
+- datalong: Despawn delay.
 
-\***SCRIPT\_COMMAND\_LOAD\_PATH = 20**
+#### \*SCRIPT\_COMMAND\_LOAD\_PATH = 20
 
--   -   source: Unit.
-    -   datalong: Path ID. See [waypoint\_data.id](waypoint_data_2130114.html#waypoint_data-id).
-    -   datalong2: If value &gt; 0, means waypoint movement is repeatable.
+- source: Unit.
+- datalong: Path ID. See [waypoint\_data.id](waypoint_data#id).
+- datalong2: If value &gt; 0, means waypoint movement is repeatable.
 
-\***SCRIPT\_COMMAND\_CALLSCRIPT\_TO\_UNIT = 21**
+#### \*SCRIPT\_COMMAND\_CALLSCRIPT\_TO\_UNIT = 21
 
--   -   source: if present, used as a search center.
-    -   datalong: entry of searched creature, if source exists, guid of the creature otherwise.
+- source: if present, used as a search center.
+- datalong: entry of searched creature, if source exists, guid of the creature otherwise.
         \*\*datalong2: ID of the script from \*\_scripts table.
-    -   dataint:
-        -   3 - use spell\_scripts table;
-        -   5 - use event\_scripts table;
-        -   6 - use waypoint\_scripts table.
+- dataint:
+  - 3 - use spell\_scripts table;
+  - 5 - use event\_scripts table;
+  - 6 - use waypoint\_scripts table.
 
-\***SCRIPT\_COMMAND\_KILL = 22**
+#### \*SCRIPT\_COMMAND\_KILL = 22
 
--   -   source: Creature.
-    -   dataint: if value == 1 remove corpse.
+- source: Creature.
+- dataint: if value == 1 remove corpse.
 
-\***SCRIPT\_COMMAND\_ORIENTATION = 30**
+#### \*SCRIPT\_COMMAND\_ORIENTATION = 30
 
--   -   source: Unit.
-    -   target: Unit (datalong != 0).
-    -   datalong: If value != 0, then turn to face the target; otherwise turn to value in o.
-    -   o: Set orientation to value in field \`o\`.
+- source: Unit.
+- target: Unit (datalong != 0).
+- datalong: If value != 0, then turn to face the target; otherwise turn to value in o.
+- o: Set orientation to value in field \`o\`.
 
-\***SCRIPT\_COMMAND\_EQUIP = 31**
+#### \*SCRIPT\_COMMAND\_EQUIP = 31
 
--   -   source: Creature.
-    -   datalong: ID (1, 2, 3 ...)  from equipment entry. See [creature\_equip\_template](creature_equip_template_2129998.html#creature_equip_template-ID).ID
+- source: Creature.
+- datalong: ID (1, 2, 3 ...)  from equipment entry. See [creature\_equip\_template.id](creature_equip_template#id)
 
-\***SCRIPT\_COMMAND\_MODEL = 32**
+#### \*SCRIPT\_COMMAND\_MODEL = 32
 
--   -   source: Creature.
-    -   datalong: model ID.
+- source: Creature.
+- datalong: model ID.
 
-\***SCRIPT\_COMMAND\_CLOSE\_GOSSIP = 33**
+#### \*SCRIPT\_COMMAND\_CLOSE\_GOSSIP = 33
 
--   -   source: Player.
+- source: Player.
 
-\***SCRIPT\_COMMAND\_PLAYMOVIE = 34**
+#### \*SCRIPT\_COMMAND\_PLAYMOVIE = 34
 
--   -   source: Player.
-    -   datalong: movie ID.
+- source: Player.
+- datalong: movie ID.
 
-\***SCRIPT\_COMMAND\_MOVEMENT = 35**
+#### \*SCRIPT\_COMMAND\_MOVEMENT = 35
 
--   -   source: Creature.
-    -   datalong: MovementType.
-    -   datalong2: MovementDistance (e.g. spawndist for MovementType 1).
-    -   dataint: pathid (for MovementType 2, see [waypoint\_data.id](waypoint_data.md#id)).
+- source: Creature.
+- datalong: MovementType.
+- datalong2: MovementDistance (e.g. spawndist for MovementType 1).
+- dataint: pathid (for MovementType 2, see [waypoint\_data.id](waypoint_data#id)).
 
 ### guid
 
-`field-no-description|5`
+Exists only for 'waypoint_scripts' and acts there as primary key; it is set automatically using the [GM command](GM-Commands) 'wp event add'.
 
-td class=

--- a/docs/smart_scripts.md
+++ b/docs/smart_scripts.md
@@ -1,3 +1,5 @@
+[Database Structure](Database-Structure) > [World-Database](World-Database) > [smart_scripts](smart_scripts)
+
 # smart\_scripts
 
 **Table Structure**
@@ -868,7 +870,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_EVENT_RECEIVE_EMOTE</p></td>
 <td><p>22</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId</a></p></td>
+<td><p><a href="Emotes">EmoteId</a></p></td>
 <td><p>CooldownMin</p></td>
 <td><p>CooldownMax</p></td>
 <td><p></p></td>
@@ -1295,8 +1297,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_EVENT_TEXT_OVER</p></td>
 <td><p>52</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_text#groupid">creature_text.GroupID</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature#id">creature.id</a> (0 any)</p></td>
+<td><p><a href="creature_text#groupid">creature_text.GroupID</a></p></td>
+<td><p><a href="creature#id">creature.id</a> (0 any)</p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1428,15 +1430,15 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_EVENT_GOSSIP_SELECT</p></td>
 <td><p>62</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gossip_menu_option#menuid">gossip_menu_option.MenuID</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gossip_menu_option#optionid">gossip_menu_option.OptionID</a></p></td>
+<td><p><a href="gossip_menu_option#menuid">gossip_menu_option.MenuID</a></p></td>
+<td><p><a href="gossip_menu_option#optionid">gossip_menu_option.OptionID</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
 </p></td>
-<td>On gossip clicked (<a href="http://www.azerothcore.org/wiki/gossip_menu_option">gossip_menu_option</a>).</td>
+<td>On gossip clicked (<a href="gossip_menu_option">gossip_menu_option</a>).</td>
 </tr>
 <tr class="even">
 <td><p>SMART_EVENT_JUST_CREATED</p></td>
@@ -1518,7 +1520,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_EVENT_GAME_EVENT_START</p></td>
 <td><p>68</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/game_event#evententry">game_event.eventEntry</a></p></td>
+<td><p><a href="game_event#evententry">game_event.eventEntry</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1527,12 +1529,12 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </p></td>
 <td><p><br />
 </p></td>
-<td>On <a href="http://www.azerothcore.org/wiki/game_event">game_event</a> started.</td>
+<td>On <a href="game_event">game_event</a> started.</td>
 </tr>
 <tr class="even">
 <td><p>SMART_EVENT_GAME_EVENT_END</p></td>
 <td><p>69</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/game_event#evententry">game_event.eventEntry</a></p></td>
+<td><p><a href="game_event#evententry">game_event.eventEntry</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1541,7 +1543,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </p></td>
 <td><p><br />
 </p></td>
-<td>On <a href="http://www.azerothcore.org/wiki/game_event">game_event</a> ended.</td>
+<td>On <a href="game_event">game_event</a> ended.</td>
 </tr>
 <tr class="odd">
 <td><p>SMART_EVENT_GO_STATE_CHANGED</p></td>
@@ -1689,7 +1691,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_TALK</p></td>
 <td><p>1</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_text#groupid">creature_text.GroupID</a></p></td>
+<td><p><a href="creature_text#groupid">creature_text.GroupID</a></p></td>
 <td><p>Duration to wait before SMART_EVENT_TEXT_OVER is triggered.</p></td>
 <td>0 It will try to trigger talk of the target
 <p>1 Set target as talk target (used for $vars in texts and whisper target)</p></td>
@@ -1704,7 +1706,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SET_FACTION</p></td>
 <td><p>2</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/FactionTemplate">FactionID</a> (or 0 for default)</p></td>
+<td><p><a href="FactionTemplate">FactionID</a> (or 0 for default)</p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1720,8 +1722,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_MORPH_TO_ENTRY_OR_MODEL</p></td>
 <td><p>3</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a>(param1)</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#modelidx">creature_template.modelidx</a>(param2)</p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a>(param1)</p></td>
+<td><p><a href="creature_template#modelidx">creature_template.modelidx</a>(param2)</p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1750,7 +1752,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_PLAY_EMOTE</p></td>
 <td><p>5</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId</a></p></td>
+<td><p><a href="Emotes">EmoteId</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1782,7 +1784,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_OFFER_QUEST</p></td>
 <td><p>7</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></p></td>
+<td><p><a href="quest_template#id">quest_template.id</a></p></td>
 <td><p>directAdd (0/1)</p></td>
 <td><p><br />
 </p></td>
@@ -1830,12 +1832,12 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_RANDOM_EMOTE</p></td>
 <td><p>10</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId1</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId2</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId3</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId4</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId5</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId6</a></p></td>
+<td><p><a href="Emotes">EmoteId1</a></p></td>
+<td><p><a href="Emotes">EmoteId2</a></p></td>
+<td><p><a href="Emotes">EmoteId3</a></p></td>
+<td><p><a href="Emotes">EmoteId4</a></p></td>
+<td><p><a href="Emotes">EmoteId5</a></p></td>
+<td><p><a href="Emotes">EmoteId6</a></p></td>
 <td><p>Play Random Emote</p></td>
 </tr>
 <tr class="even">
@@ -1897,7 +1899,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_CALL_AREAEXPLOREDOREVENTHAPPENS</p></td>
 <td><p>15</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></p></td>
+<td><p><a href="quest_template#id">quest_template.id</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1931,7 +1933,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_SET_EMOTE_STATE</p></td>
 <td><p>17</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Emotes">EmoteId</a></p></td>
+<td><p><a href="Emotes">EmoteId</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1949,8 +1951,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <td><p>18</p></td>
 <td><p>(may be more than one field OR'd together)</p></td>
 <td><p>type</p>
-<p>If false set <a href="http://www.azerothcore.org/wiki/creature_template#unit_flags">creature_template.unit_flags</a></p>
-<p>If true set <a href="http://www.azerothcore.org/wiki/creature_template#unit_flags2">creature_template.unit_flags2</a></p></td>
+<p>If false set <a href="creature_template#unit_flags">creature_template.unit_flags</a></p>
+<p>If true set <a href="creature_template#unit_flags2">creature_template.unit_flags2</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -1966,8 +1968,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <td><p>19</p></td>
 <td><p>(may be more than one field OR'd together)</p></td>
 <td><p>type</p>
-<p>If false set  <a href="http://www.azerothcore.org/wiki/creature_template#unit_flags">creature_template.unit_flags</a></p>
-<p>If true set <a href="http://www.azerothcore.org/wiki/creature_template#unit_flags2">creature_template.unit_flags2</a></p></td>
+<p>If false set  <a href="creature_template#unit_flags">creature_template.unit_flags</a></p>
+<p>If true set <a href="creature_template#unit_flags2">creature_template.unit_flags2</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2077,7 +2079,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_CALL_GROUPEVENTHAPPENS</p></td>
 <td><p>26</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></p></td>
+<td><p><a href="quest_template#id">quest_template.id</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2130,7 +2132,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <td><p>29</p></td>
 <td><p>Distance (0 = Default value)</p></td>
 <td><p>Angle (0 = Default value)</p></td>
-<td><p>End <a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a></p></td>
+<td><p>End <a href="creature_template#entry">creature_template.entry</a></p></td>
 <td><p>credit</p></td>
 <td><p>creditType (0 monsterkill, 1 event)</p></td>
 <td><p><br />
@@ -2185,7 +2187,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_CALL_KILLEDMONSTER</p></td>
 <td><p>33</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a></p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2196,7 +2198,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 </p></td>
 <td><p><br />
 </p></td>
-<td><p>This is the ID from <a href="http://www.azerothcore.org/wiki/quest_template#requirednpcorgo">quest_template.RequiredNpcOrGo</a></p></td>
+<td><p>This is the ID from <a href="quest_template#requirednpcorgo">quest_template.RequiredNpcOrGo</a></p></td>
 </tr>
 <tr class="odd">
 <td><p>SMART_ACTION_SET_INST_DATA</p></td>
@@ -2232,7 +2234,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_UPDATE_TEMPLATE</p></td>
 <td><p>36</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a></p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a></p></td>
 <td><p>Update Level</p></td>
 <td><p><br />
 </p></td>
@@ -2346,7 +2348,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <td><p>SMART_ACTION_MOUNT_TO_ENTRY_OR_MODEL</p></td>
 <td><p>43</p></td>
 <td><p>creature_template.entry</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#modelidx">creature_template.modelidx</a></p></td>
+<td><p><a href="creature_template#modelidx">creature_template.modelidx</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2360,7 +2362,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SET_INGAME_PHASE_MASK</p></td>
 <td><p>44</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature#phasemask">creature.phaseMask</a></p></td>
+<td><p><a href="creature#phasemask">creature.phaseMask</a></p></td>
 <td><p>mask</p></td>
 <td><p><br />
 </p></td>
@@ -2456,7 +2458,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SUMMON_GO</p></td>
 <td><p>50</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a></p></td>
+<td><p><a href="gameobject_template#entry">gameobject_template.entry</a></p></td>
 <td><p>De-spawn time in seconds.</p></td>
 <td><p>targetSummon (0/1)</p></td>
 <td><p><br />
@@ -2504,12 +2506,12 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <td><p>SMART_ACTION_WP_START</p></td>
 <td><p>53</p></td>
 <td><p>0 = walk / 1 = run</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/waypoints#entry">waypoints.entry</a></p></td>
+<td><p><a href="waypoints#entry">waypoints.entry</a></p></td>
 <td><p>canRepeat</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></p></td>
+<td><p><a href="quest_template#id">quest_template.id</a></p></td>
 <td><p>despawntime</p></td>
 <td><p>reactState</p></td>
-<td><p>Creature starts Waypoint Movement. Use <a href="http://www.azerothcore.org/wiki/waypoints#entry">waypoints</a> table to create movement.</p></td>
+<td><p>Creature starts Waypoint Movement. Use <a href="waypoints#entry">waypoints</a> table to create movement.</p></td>
 </tr>
 <tr class="odd">
 <td><p>SMART_ACTION_WP_PAUSE</p></td>
@@ -2531,7 +2533,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <td><p>SMART_ACTION_WP_STOP</p></td>
 <td><p>55</p></td>
 <td><p>despawnTime</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></p></td>
+<td><p><a href="quest_template#id">quest_template.id</a></p></td>
 <td><p>fail (0/1)</p></td>
 <td><p><br />
 </p></td>
@@ -2544,7 +2546,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_ADD_ITEM</p></td>
 <td><p>56</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a></p></td>
+<td><p><a href="item_template#entry">item_template.entry</a></p></td>
 <td><p>count</p></td>
 <td><p><br />
 </p></td>
@@ -2559,7 +2561,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_REMOVE_ITEM</p></td>
 <td><p>57</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a></p></td>
+<td><p><a href="item_template#entry">item_template.entry</a></p></td>
 <td><p>count</p></td>
 <td><p><br />
 </p></td>
@@ -2639,7 +2641,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_TELEPORT</p></td>
 <td><p>62</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/Map">MapID</a></p></td>
+<td><p><a href="Map">MapID</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2780,11 +2782,11 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_EQUIP</p></td>
 <td><p>71</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_equip_template#creatureid">creature_equip_template.CreatureID</a></p></td>
+<td><p><a href="creature_equip_template#creatureid">creature_equip_template.CreatureID</a></p></td>
 <td><p>Slotmask</p></td>
-<td><p>Slot1 (<a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a>)</p></td>
-<td><p>Slot2 (<a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a>)</p></td>
-<td><p>Slot3 (<a href="http://www.azerothcore.org/wiki/item_template#entry">item_template.entry</a>)</p></td>
+<td><p>Slot1 (<a href="item_template#entry">item_template.entry</a>)</p></td>
+<td><p>Slot2 (<a href="item_template#entry">item_template.entry</a>)</p></td>
+<td><p>Slot3 (<a href="item_template#entry">item_template.entry</a>)</p></td>
 <td><p><br />
 </p></td>
 <td><p>only slots with mask set will be sent to client, bits are 1, 2, 4, leaving mask 0 is defaulted to mask 7 (send all), Slots1-3 are only used if no Param1 is set</p></td>
@@ -2943,7 +2945,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_SET_NPC_FLAG</p></td>
 <td><p>81</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#npcflag">creature_template.npcflag</a></p></td>
+<td><p><a href="creature_template#npcflag">creature_template.npcflag</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2960,7 +2962,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_ADD_NPC_FLAG</p></td>
 <td><p>82</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#npcflag">creature_template.npcflag</a></p></td>
+<td><p><a href="creature_template#npcflag">creature_template.npcflag</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2977,7 +2979,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_REMOVE_NPC_FLAG</p></td>
 <td><p>83</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#npcflag">creature_template.npcflag</a></p></td>
+<td><p><a href="creature_template#npcflag">creature_template.npcflag</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -2994,7 +2996,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SIMPLE_TALK</p></td>
 <td><p>84</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_text#groupid">creature_text.GroupID</a></p></td>
+<td><p><a href="creature_text#groupid">creature_text.GroupID</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3140,7 +3142,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SET_DYNAMIC_FLAG</p></td>
 <td><p>94</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#dynamicflags">creature_template.dynamicflags</a></p></td>
+<td><p><a href="creature_template#dynamicflags">creature_template.dynamicflags</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3157,7 +3159,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_ADD_DYNAMIC_FLAG</p></td>
 <td><p>95</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#dynamicflags">creature_template.dynamicflags</a></p></td>
+<td><p><a href="creature_template#dynamicflags">creature_template.dynamicflags</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3174,7 +3176,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_REMOVE_DYNAMIC_FLAG</p></td>
 <td><p>96</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#dynamicflags">creature_template.dynamicflags</a></p></td>
+<td><p><a href="creature_template#dynamicflags">creature_template.dynamicflags</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3205,9 +3207,9 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SEND_GOSSIP_MENU</p></td>
 <td><p>98</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gossip_menu#entry">gossip_menu.entry</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gossip_menu#text_id">gossip_menu.text_id</a><br />
-(same value as <a href="http://www.azerothcore.org/wiki/npc_text#id">npc_text.ID</a>)</p></td>
+<td><p><a href="gossip_menu#entry">gossip_menu.entry</a></p></td>
+<td><p><a href="gossip_menu#text_id">gossip_menu.text_id</a><br />
+(same value as <a href="npc_text#id">npc_text.ID</a>)</p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3304,7 +3306,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_SET_GO_FLAG</p></td>
 <td><p>104</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template_addon#flags">gameobject_template_addon.flags</a></p></td>
+<td><p><a href="gameobject_template_addon#flags">gameobject_template_addon.flags</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3320,7 +3322,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_ADD_GO_FLAG</p></td>
 <td><p>105</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template_addon#flags">gameobject_template_addon.flags</a></p></td>
+<td><p><a href="gameobject_template_addon#flags">gameobject_template_addon.flags</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3336,7 +3338,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_REMOVE_GO_FLAG</p></td>
 <td><p>106</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template_addon#flags">gameobject_template_addon.flags</a></p></td>
+<td><p><a href="gameobject_template_addon#flags">gameobject_template_addon.flags</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3352,7 +3354,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_SUMMON_CREATURE_GROUP</p></td>
 <td><p>107</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_summon_groups#groupid">creature_summon_groups.groupId</a></p></td>
+<td><p><a href="creature_summon_groups#groupid">creature_summon_groups.groupId</a></p></td>
 <td><p>attackInvoker (0/1)</p></td>
 <td><p>attackScriptOwner (0/1)</p></td>
 <td><p><br />
@@ -3414,7 +3416,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_ACTION_GAME_EVENT_STOP</p></td>
 <td><p>111</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/game_event#evententry">game_event.eventEntry</a></p></td>
+<td><p><a href="game_event#evententry">game_event.eventEntry</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -3431,7 +3433,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_ACTION_GAME_EVENT_START</p></td>
 <td><p>112</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/game_event#evententry">game_event.eventEntry</a></p></td>
+<td><p><a href="game_event#evententry">game_event.eventEntry</a></p></td>
 <td><p><br />
 </p></td>
 <td><p><br />
@@ -4370,7 +4372,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_TARGET_CREATURE_RANGE</p></td>
 <td><p>9</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a> (0 any)</p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a> (0 any)</p></td>
 <td><p>minDist</p></td>
 <td><p>maxDist</p></td>
 <td><p>alive state (1 alive, 2 dead, 0 both)</p></td>
@@ -4387,8 +4389,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_TARGET_CREATURE_GUID</p></td>
 <td><p>10</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature#guid">creature.guid</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a></p></td>
+<td><p><a href="creature#guid">creature.guid</a></p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a></p></td>
 <td><p>getFromHashMap (0/1, this does not work in instances!)</p></td>
 <td><p><br />
 </p></td>
@@ -4405,7 +4407,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_TARGET_CREATURE_DISTANCE</p></td>
 <td><p>11</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a> (0 any)</p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a> (0 any)</p></td>
 <td><p>maxDist</p></td>
 <td><p>alive state (1 alive, 2 dead, 0 both)</p></td>
 <td><p><br />
@@ -4443,7 +4445,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_TARGET_GAMEOBJECT_RANGE</p></td>
 <td><p>13</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a> (0 any)</p></td>
+<td><p><a href="gameobject_template#entry">gameobject_template.entry</a> (0 any)</p></td>
 <td><p>minDist</p></td>
 <td><p>maxDist</p></td>
 <td><p><br />
@@ -4461,8 +4463,8 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_TARGET_GAMEOBJECT_GUID</p></td>
 <td><p>14</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject#guid">gameobject.guid</a></p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a></p></td>
+<td><p><a href="gameobject#guid">gameobject.guid</a></p></td>
+<td><p><a href="gameobject_template#entry">gameobject_template.entry</a></p></td>
 <td><p>getFromHashMap (0/1, this does not work in instances!)</p></td>
 <td><p><br />
 </p></td>
@@ -4479,7 +4481,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_TARGET_GAMEOBJECT_DISTANCE</p></td>
 <td><p>15</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a> (0 any)</p></td>
+<td><p><a href="gameobject_template#entry">gameobject_template.entry</a> (0 any)</p></td>
 <td><p>maxDist</p></td>
 <td><p><br />
 </p></td>
@@ -4557,7 +4559,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="even">
 <td><p>SMART_TARGET_CLOSEST_CREATURE</p></td>
 <td><p>19</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/creature_template#entry">creature_template.entry</a> (0 any)</p></td>
+<td><p><a href="creature_template#entry">creature_template.entry</a> (0 any)</p></td>
 <td><p>maxDist (Can be from 0-100 yards)</p></td>
 <td><p>dead? (0/1)</p></td>
 <td><p><br />
@@ -4575,7 +4577,7 @@ This is the probability of the event to occur as a percentage from 0-100. So, if
 <tr class="odd">
 <td><p>SMART_TARGET_CLOSEST_GAMEOBJECT</p></td>
 <td><p>20</p></td>
-<td><p><a href="http://www.azerothcore.org/wiki/gameobject_template#entry">gameobject_template.entry</a> (0 any)</p></td>
+<td><p><a href="gameobject_template#entry">gameobject_template.entry</a> (0 any)</p></td>
 <td><p>maxDist (Can be from 0-100 yards)</p></td>
 <td><p><br />
 </p></td>
@@ -4914,5 +4916,4 @@ SMART\_EVENT\_INSTANCE\_PLAYER\_ENTER
 SMART\_EVENT\_TRANSPORT\_ADDCREATURE
 
 SMART\_EVENT\_DATA\_SET
-
 

--- a/docs/spell_scripts.md
+++ b/docs/spell_scripts.md
@@ -1,15 +1,24 @@
 [Database Structure](Database-Structure) > [World-Database](World-Database) > [spell_scripts](spell_scripts)
 
-Column | Type | Description
---- | --- | ---
-Id | mediumint(8) unsigned | 
-EffIndex | tinyint(3) unsigned | 
-Delay | int(10) unsigned | 
-Command | mediumint(8) unsigned | 
-Datalong | mediumint(8) unsigned | 
-Datalong2 | int(10) unsigned | 
-Dataint | int(11) | 
-X | float | 
-Y | float | 
-Z | float | 
-O | float | 
+# spell\_scripts
+
+### Information
+
+Holds scripts that can be activated by spells with effect SPELL\_EFFECT\_SCRIPT\_EFFECT (77) or SPELL\_EFFECT\_DUMMY(3).
+
+### Structure
+
+| Field                            | Type         | Attributes   | Key | Null | Default |
+|----------------------------------|--------------|--------------|-----|------|---------|
+| [id](scripts#id)                 | mediumint(8) | unsigned     |     | NO   | 0       |
+| [effIndex](scripts#effindex)     | tinyint(3)   | unsigned     |     | NO   | 0       |
+| [delay](scripts#delay)           | int(10)      | unsigned     |     | NO   | 0       |
+| [command](scripts#command)       | mediumint(8) | unsigned     |     | NO   | 0       |
+| [datalong](scripts#otherfields)  | mediumint(8) | unsigned     |     | NO   | 0       |
+| [datalong2](scripts#otherfields) | int(10)      | unsigned     |     | NO   | 0       |
+| [dataint](scripts#otherfields)   | int(11)      |              |     | NO   | 0       |
+| [x](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [y](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [z](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [o](scripts#otherfields)         | float        |              |     | NO   | 0       |
+

--- a/docs/waypoint_data.md
+++ b/docs/waypoint_data.md
@@ -1,33 +1,26 @@
+[Database Structure](Database-Structure) > [World-Database](World-Database) > [waypoint_data](waypoint_data)
+
 # waypoint\_data
-
-[<-Back-to:World](database-world.md)
-
-## **Version 3.3.5a**
 
 ### Information
 
-This table contains all the path data for creatures that use waypoints.
-
-|         |                       |
-|---------|-----------------------|
-| Collate | *'utf8\_general\_ci'* |
-| Engine  | MyISAM                |
+This table contains all the path data for creatures that use waypoints and waypoint scripts directly in their creature addon definition. See also [Waypoints-Information](Waypoints-Information) for general information about waypoints.
 
 ### Structure
 
-| Field                                          | Type         | Attributes | Key | Null | Default | Comment       |
-|------------------------------------------------|--------------|------------|-----|------|---------|---------------|
-| [id](#waypoint_data-id)                        | INT(10)      | UNSIGNED   | PRI | NO   | 0       | Creature GUID |
-| [point](#waypoint_data-point)                  | MEDIUMINT(8) | UNSIGNED   | PRI | NO   | 0       | -             |
-| [position\_x](#waypoint_data-position)         | FLOAT        | -          | -   | NO   | 0       | -             |
-| [position\_y](#waypoint_data-position)         | FLOAT        | -          | -   | NO   | 0       | -             |
-| [position\_z](#waypoint_data-position)         | FLOAT        | -          | -   | NO   | 0       | -             |
-| [orientation](#waypoint_data-orientation)      | FLOAT        | -          | -   | NO   | 0       | -             |
-| [delay](#waypoint_data-delay)                  | INT(10)      | UNSIGNED   | -   | NO   | 0       | -             |
-| [move\_type](#waypoint_data-move_type)         | TINYINT(1)   | -          | -   | NO   | 0       | -             |
-| [action](#waypoint_data-action)                | INT(11)      | -          | -   | NO   | 0       | -             |
-| [action\_chance](#waypoint_data-action_chance) | SMALLINT(3)  | -          | -   | NO   | 100     | -             |
-| [wpguid](#waypoint_data-wpguid)                | INT(11)      | -          | -   | NO   | 0       | -             |
+| Field                            | Type         | Attributes   | Key | Null | Default |
+|----------------------------------|--------------|--------------|-----|------|---------|
+| [id](#id)                        | int(10)      | unsigned     | PRI | NO   | 0       |
+| [point](#point)                  | mediumint(8) | unsigned     | PRI | NO   | 0       |
+| [position\_x](#position_x)       | float        |              |     | NO   | 0       |
+| [position\_y](#position_y)       | float        |              |     | NO   | 0       |
+| [position\_z](#position_z)       | float        |              |     | NO   | 0       |
+| [orientation](#orientation)      | float        |              |     | NO   | 0       |
+| [delay](#delay)                  | int(10)      | unsigned     |     | NO   | 0       |
+| [move\_type](#move_type)         | int(11)      |              |     | NO   | 0       |
+| [action](#action)                | int(11)      |              |     | NO   | 0       |
+| [action\_chance](#action_chance) | smallint(6)  |              |     | NO   | 100     |
+| [wpguid](#wpguid)                | int(11)      | unsigned     |     | NO   | 0       |
 
 #### id
 
@@ -73,7 +66,7 @@ Time to wait (in ms) between each point.
 
 #### action
 
-ID of the action to be performed. See [waypoint\_scripts.id](https://trinitycore.atlassian.net/wiki/display/tc/scripts#scripts-id).
+ID of the action to be performed. See [waypoint\_scripts.id](waypoint_scripts).
 
 #### action\_chance
 
@@ -91,5 +84,4 @@ This field holds the GUID of the waypoint visual when you enable the visual mode
 |-------|-------|-------------|-------------|-------------|-------------|-------|------------|--------|----------------|--------|
 | 20160 | 1     | -4998       | -1167       | 501657      | 0           | 10000 | 0          | 0      | 100            | 0      |
 | 20160 | 2     | -4958.38    | -1199.34    | 501659      | 0           | 0     | 0          | 0      | 100            | 0      |
-
 

--- a/docs/waypoint_scripts.md
+++ b/docs/waypoint_scripts.md
@@ -1,15 +1,26 @@
 [Database Structure](Database-Structure) > [World-Database](World-Database) > [waypoint_scripts](waypoint_scripts)
 
-Column | Type | Description
---- | --- | ---
-Id | int(11) unsigned | 
-Delay | int(11) unsigned | 
-Command | int(11) unsigned | 
-Datalong | int(11) unsigned | 
-Datalong2 | int(11) unsigned | 
-Dataint | int(11) unsigned | 
-X | float | 
-Y | float | 
-Z | float | 
-O | float | 
-Guid | int(11) | 
+# waypoint\_scripts
+
+###### **Used by [waypoint_data](waypoint_data)**
+
+### Information
+
+Waypoint paths directly attached to a creature via [creature_addon.path_id](creature_addon#path_id) use the tables [waypoint_data](waypoint_data) and [waypoint_scripts](waypoint_scripts). They can be added and manipulated using the GM '.wp' commands. See also [Waypoints-Information](Waypoints-Information) for general information about waypoints.
+
+### Structure
+
+| Field                            | Type         | Attributes   | Key | Null | Default | Comment
+|----------------------------------|--------------|--------------|-----|------|---------|--------
+| [id](scripts#id)                 | int(11)      | unsigned     |     | NO   | 0       |
+| [delay](scripts#delay)           | int(11)      | unsigned     |     | NO   | 0       |
+| [command](scripts#command)       | int(11)      | unsigned     |     | NO   | 0       |
+| [datalong](scripts#otherfields)  | int(11)      | unsigned     |     | NO   | 0       |
+| [datalong2](scripts#otherfields) | int(11)      | unsigned     |     | NO   | 0       |
+| [dataint](scripts#otherfields)   | int(11)      | unsigned     |     | NO   | 0       |
+| [x](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [y](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [z](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [o](scripts#otherfields)         | float        |              |     | NO   | 0       |
+| [guid](scripts#guid)             | int(11)      |              | PRI | NO   | 0       | acts as primary key and is set automatically using the [GM command](GM-Commands) 'wp event add'
+

--- a/docs/waypoints.md
+++ b/docs/waypoints.md
@@ -1,36 +1,27 @@
+[Database Structure](Database-Structure) > [World-Database](World-Database) > [waypoints](waypoints)
+
 # waypoints
 
-[<-Back-to:World](database-world.md)
-
-###### **Used by [SAI](https://trinitycore.atlassian.net/wiki/display/tc/smart_scripts)**
-
-## **Version 3.3.5a**
+###### **Used by [SAI](smart_scripts)**
 
 ### Information
 
-Contains waypoint data, allowing Creatures to move to certain X, Y, and Z coordinates.
-
-|            |                      |
-|------------|----------------------|
-| Comment    | *Creature waypoints* |
-| Collate    | *utf8\_general\_ci*  |
-| Engine     | MyISAM               |
-| Row Format | FIXED                |
+Contains waypoint data, allowing creatures to move to certain X, Y, and Z coordinates. See also [Waypoints-Information](Waypoints-Information) for general information about waypoints.
 
 ### Structure
 
-| Field                                                                                                 | Type         | Attributes | Key | Null | Default |
-|-------------------------------------------------------------------------------------------------------|--------------|------------|-----|------|---------|
-| [entry](https://trinitycore.atlassian.net/wiki/display/tc/waypoints#waypoints-entry)                  | MEDIUMINT(8) | UNSIGNED   | PRI | NO   | 0       |
-| [pointid](https://trinitycore.atlassian.net/wiki/display/tc/waypoints#waypoints-pointid)              | MEDIUMINT(8) | UNSIGNED   | PRI | NO   | 0       |
-| [position\_x](https://trinitycore.atlassian.net/wiki/display/tc/waypoints#waypoints-position_x)       | FLOAT        | -          | -   | NO   | 0       |
-| [position\_y](https://trinitycore.atlassian.net/wiki/display/tc/waypoints#waypoints-position_y)       | FLOAT        | -          | -   | NO   | 0       |
-| [position\_z](https://trinitycore.atlassian.net/wiki/display/tc/waypoints#waypoints-position_z)       | FLOAT        | -          | -   | NO   | 0       |
-| [point\_comment](https://trinitycore.atlassian.net/wiki/display/tc/waypoints#waypoints-point_comment) | TEXT         | -          | -   | YES  | -       |
+| Field                            | Type         | Attributes | Key | Null | Default |
+|----------------------------------|--------------|------------|-----|------|---------|
+| [entry](#entry)                  | mediumint(8) | unsigned   | PRI | NO   | 0       |
+| [pointid](#pointid)              | mediumint(8) | unsigned   | PRI | NO   | 0       |
+| [position\_x](#position_x)       | float        |            |     | NO   | 0       |
+| [position\_y](#position_y)       | float        |            |     | NO   | 0       |
+| [position\_z](#position_z)       | float        |            |     | NO   | 0       |
+| [point\_comment](#point_comment) | text         |            |     | YES  | NULL    |
 
 #### entry
 
-Entry of the creature. See [creature\_template.entry](https://trinitycore.atlassian.net/wiki/display/tc/creature_template#creature_template-entry).
+Path ID. Standard way of assigning an ID is [creature\_template.entry](creature_template#entry) * 100, but any random number can be used here.
 
 #### pointid
 
@@ -54,11 +45,10 @@ Text comment.
 
 ### Example Rows
 
-| Entry | Pointid | Position\_x | Position\_y | Position\_z | Point\_comment           |
+| entry | pointid | position\_x | position\_y | position\_z | point\_comment           |
 |-------|---------|-------------|-------------|-------------|--------------------------|
 | 16208 | 1       | 6647.83     | -6344.92    | 9.13345     | Apothecary Enith point 1 |
 | 16208 | 2       | 6657.92     | -6345.96    | 15.3468     | Apothecary Enith point 2 |
 
 Creature with ID 16208 will now have 2 waypoints, first it will move to pointid 1, when it reaches the XYZ position, it will move to pointid 2. The comment helps clarify which creature the ID belongs to.
-
 


### PR DESCRIPTION
- Updated all DB pages concerning waypoints and also updated the scripts documentation on this occasion:
  ```
  scripts
  event_scripts
  spell_scripts
  waypoint_scripts
  waypoint_data
  waypoints
  script_waypoint
  ```

- Updated ```smart_scripts``` in order to use relative links (missed this in my last PR).

- Provided a new page containing general information about waypoints and linked it under "Other" in the sidebar:
  ```
  Waypoints-Information
  ```
  This page provides information about the 3 different waypoint systems and on the usage of the ".wp" command for game masters.