### PR TITLE
Update Requirements concerning cmake

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -30,6 +30,15 @@ For example, if you are using an older version of Ubuntu like 16.04, you need to
 
 If you use another distro or version, search on google for how to install the right clang version for your system.
 
+### Check your cmake version
+
+`cmake --version`
+
+Your `cmake` version **MUST** be `3.8` or higher.
+
+If you are using an older version of Ubuntu like 16.04, you need to follow the instructions here in order to install the latest version:
+https://apt.kitware.com/
+
 
 # Mac OS X
 


### PR DESCRIPTION
Since commit https://github.com/azerothcore/azerothcore-wotlk/commit/0e6c9a18f4f3f82ec431aad7101bdf58b8f5d63f it is necessary to use at least cmake version 3.8. Ubuntu 16.04 uses version 3.5.1 as default, so you have to install the latest version as described here:
https://apt.kitware.com/