### PR TITLE
Update Requirements concerning gcc-7

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -39,6 +39,13 @@ Your `cmake` version **MUST** be `3.8` or higher.
 If you are using an older version of Ubuntu like 16.04, you need to follow the instructions here in order to install the latest version:
 https://apt.kitware.com/
 
+### Ensure that the gcc-7 headers are installed
+
+This is an issue if for example using an older version of Ubuntu like 16.04. There you have to add the PPA "Toolchain test builds":
+https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
+
+After `sudo apt-get update` you can install gcc-7: `sudo apt-get install g++-7 gcc-7`
+
 
 # Mac OS X
 


### PR DESCRIPTION
It seems that after commit https://github.com/azerothcore/azerothcore-wotlk/commit/0e6c9a18f4f3f82ec431aad7101bdf58b8f5d63f there are also build errors on Ubuntu 16.04:

```
azerothcore/src/server/scripts/Northrend/DraktharonKeep/boss_novos.cpp:57:65: fatal error: no matching constructor for initialization of 'const std::unordered_map<uint32, std::tuple<uint32, Position> >' (aka 'const unordered_map<unsigned int, tuple<unsigned int, Position> >')
std::unordered_map<uint32, std::tuple <uint32, Position>> const npcSummon =
                                                                ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unordered_map.h:142:7: note: candidate constructor not viable: cannot convert initializer list argument to 'std::unordered_map<unsigned int, std::tuple<unsigned int, Position>, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<const unsigned int, std::tuple<unsigned int, Position> > > >::size_type' (aka 'unsigned long')
      unordered_map(size_type __n,
      ^
```

Although using clang 7 it seems that clang depends on gcc headers. Those were missing, because Ubuntu 16.04 uses gcc-5. I was able to solve this by installing gcc-7 and g++-7, which should also be documented on the wiki.