### PR TITLE
Update "How-to-create-a-PR" and "Installation"

### DIFF
--- a/docs/How-to-create-a-PR.md
+++ b/docs/How-to-create-a-PR.md
@@ -112,11 +112,18 @@ git add data/sql/updates/pending_db_world/rev_XXXXXXXXXXXX.sql
 
 ### 6. Commit & Push your changes
 
-First of all, commit your changes using:
+First of all make sure to use the AC commit template (this should only be necessary once):
+```
+git config --local commit.template ".git_commit_template.txt"
+```
+
+Then commit your changes using:
 
 ```
-git commit -m "fix: write a short commit message here"
+git commit
 ```
+
+You are then prompted to specify an appropriate commit message (please follow the format guidelines here).
 
 Now it's time to push them remotely. 
 If you use the `git push` command for the first time in this branch, 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -54,10 +54,10 @@ At this point, you must be in your "build/" directory.
 **Note2**: in case you use a non-default package for `clang`, you need to replace it accordingly. For example, if you installed `clang-6.0` then you have to replace `clang` with `clang-6.0` and `clang++` with `clang++-6.0`
 
 ```
-cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DTOOLS=0 -DSCRIPTS=1
+cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DTOOLS=0 -DSCRIPTS=1 -DWITH_WARNINGS=1 -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror"
 ```
 
-Then, replacing `4` with the number of threads that you want to execute, type:
+Then, replacing `6` with the number of threads that you want to execute, type:
 
 ```
 make -j 6


### PR DESCRIPTION
- Update "How-to-create-a-PR" to include additional information concerning the AC git commit template (this should ease up naming and merging of the PRs, as they get the name of the first commit).
- Update "Installation" to enable break on warnings for cmake (similar to Travis, so that contributors hopefully fix all warnings on their local system before creating a PR).