### PR TITLE
Add Character DB Cleanup (worldserver conf) page

### DIFF
--- a/docs/CharacterDBCleanup.md
+++ b/docs/CharacterDBCleanup.md
@@ -1,0 +1,26 @@
+## Character DB Cleanup (worldserver conf)
+
+The purpose of the CharacterDB cleanup routines is to remove old, non-existent and erranous/defunct skills, talents, spells, and achievements from characters in the database.
+
+To achieve this, add an entry (number) in the worldstate-table (id:20004), combining the following arguments (bitmasked):
+
+    CLEANING_FLAG_ACHIEVEMENT_PROGRESS  = 0x1
+    CLEANING_FLAG_SKILLS                = 0x2
+    CLEANING_FLAG_SPELLS                = 0x4
+    CLEANING_FLAG_TALENTS               = 0x8
+    CLEANING_FLAG_QUESTSTATUS           = 0x10
+
+Example:
+We want to clean up old talents, spells and skills, but leave achivements alone - ie. NOT touching those. We'd then need to combine the numbers from each of the above fields:
+
+`CLEANING_FLAG_SKILLS + CLEANING_FLAG_SPELLS + CLEANING_FLAG_TALENTS`
+
+This comes out as **2+4+8 => 14**, and we now put an entry in for this in the worldstate table (this is done on the CHARACTERS database):
+
+```sql
+UPDATE worldstates SET value=14 WHERE entry=20004;
+```
+
+This will then (when the core is restarting) clean up old and missing skills, spells and talents.
+
+Please note that we are not responsible for any issues that might come from this, you are (as the owner of the database), responsible for doing proper **backups** prior to doing the above in case of anything going wrong.


### PR DESCRIPTION
Add Character DB Cleanup (worldserver conf) page

## Related Issue
In `worldserver.conf` there is a option about the cleaning of the characters DB but there is no explanation about it and the related parameters of the conf.

