### PR TITLE
Update game_event table description

### DIFF
--- a/docs/game_event.md
+++ b/docs/game_event.md
@@ -51,7 +51,7 @@ This table holds definitions for all game events that are activated or deactivat
 <td><p>NULL</p></td>
 <td><p><br />
 </p></td>
-<td><p>Absolute end date, the event will never start after</p></td>
+<td><p>Absolute end date, the event will never start after; if NULL it will be implicitly set to 2 years in the future on each server start</p></td>
 </tr>
 <tr class="odd">
 <td><p><a href="http://collab.kpsn.org#occurrence">occurrence</a></p></td>


### PR DESCRIPTION
Following commit https://github.com/azerothcore/azerothcore-wotlk/commit/42a53837c659d80ee248a1e5ec3ab050ae526249 the logic of "end_time" has been changed, so the documentation also has to be updated.