### PR TITLE
fix: item_template was wrong about gold item quality

### DIFF
--- a/docs/item_template.md
+++ b/docs/item_template.md
@@ -3046,7 +3046,7 @@ The cooldown time in milliseconds that is applied to all other spells in the cat
 
 ### bonding
 
-The bonding for the item. To use the Bind to Account bonding, the item must have its flags set to 134217728.
+The bonding for the item. To use the "Bind to Account" bonding, the item must have its `flags` set to 134217728 (minimum).
 
 <table>
 <colgroup>

--- a/docs/item_template.md
+++ b/docs/item_template.md
@@ -2121,7 +2121,7 @@ The model ID of the item. Each model has its own icon assigned so this field con
 
 ### Quality
 
-The quality of the item. To use the Bind to Account quality, the item must have its flags set to 134217728.
+The quality of the item.
 
 <table>
 <colgroup>
@@ -2175,7 +2175,7 @@ The quality of the item. To use the Bind to Account quality, the item must have 
 <tr class="even">
 <td><p>7</p></td>
 <td><p>Gold</p></td>
-<td><p>Bind to Account</p></td>
+<td><p>Heirlooms (or some Bind to Account items)</p></td>
 </tr>
 </tbody>
 </table>
@@ -3046,7 +3046,7 @@ The cooldown time in milliseconds that is applied to all other spells in the cat
 
 ### bonding
 
-The bonding for the item.
+The bonding for the item. To use the Bind to Account bonding, the item must have its flags set to 134217728.
 
 <table>
 <colgroup>


### PR DESCRIPTION
It was from TC.
It's not an item quality "bind to account", it's a bonding type because it overrides the existing bonding.
There are items that are not heirlooms but bind to accound . There are also items that are heirlooms quality and bind to account but they're not heirlooms but it's widely accepted as "heirloom quality".
