### PR TITLE
fix: Add info about quest state_mask in conditions.md

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1052,7 +1052,13 @@ CONDITION_STAND_STATE</p></td>
 <td>CONDITION_QUESTSTATE</td>
 <td>47</td>
 <td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
-<td>state_mask (1 = not taken, 2 = completed, 8 = in progress, 32 = failed, 64 = rewarded)</td>
+<td>state_mask:
+<li>1 = Not taken</li>
+<li>2 = Completed</li>
+<li>8 = In progress</li>
+<li>32 = Failed</li>
+<li>64 = Rewarded</li>
+</td>
 <td>Always 0</td>
 </tr>
 <tr class="odd">

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1052,7 +1052,7 @@ CONDITION_STAND_STATE</p></td>
 <td>CONDITION_QUESTSTATE</td>
 <td>47</td>
 <td>Quest ID - see <a href="http://www.azerothcore.org/wiki/quest_template#id">quest_template.id</a></td>
-<td>state_mask</td>
+<td>state_mask (1 = not taken, 2 = completed, 8 = in progress, 32 = failed, 64 = rewarded)</td>
 <td>Always 0</td>
 </tr>
 <tr class="odd">


### PR DESCRIPTION
This is taken fron ConditionMgr.h, sadly the condition itself doesn't exist (condition 47) on azerothcore yet (a message warned me in the console, quite neat) but we need it to fix some particular quests loot rewards

but at least the documentation will be ready for when it's ported from TC