### PR TITLE
feat: Add extra info for mail text length

### DIFF
--- a/docs/mail.md
+++ b/docs/mail.md
@@ -226,13 +226,7 @@ Here is stored mail subject.
 
 ### body
 
-The text contained in the mail.
-
-Info about the max length of a mail, from the code:
-```cpp
-    // client can't work with packets > max int16 value
-    const uint32 maxPacketSize = 32767;
-```
+The text contained in the mail. Max length is 8000 characters.
 
 ### has_items
 

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -228,13 +228,19 @@ Here is stored mail subject.
 
 The text contained in the mail.
 
-### has\_items
+Info about the max length of a mail, from the code:
+```cpp
+    // client can't work with packets > max int16 value
+    const uint32 maxPacketSize = 32767;
+```
+
+### has_items
 
 Default: 0,
 
 When is set to 1, that mail can contain items.
 
-For items look at [mail\_items](mail_items) table.
+For items look at [mail_items](mail_items) table.
 
 ### expire\_time
 


### PR DESCRIPTION
I don't know the size of the other parameters of the packet, but a mail of 8000 characters works fine. I do'nt know if we can go up to 25000 or 30000. No idea... Needs a dev to find this out, kinda why I make this PR