### PR TITLE
refactor: gm_commands ban commands

### DIFF
--- a/docs/GM-Commands.md
+++ b/docs/GM-Commands.md
@@ -22,19 +22,24 @@ Note: Some commands are working only by selecting a player or a creature. These 
 |announce|1|Syntax: .announce $MessageToBroadcast Send a global message to all players online in chat log.|
 |arena captain|3|Syntax: .arena captain #TeamID $name. A command to set new captain to the team. $name must be in the team|
 |aura|3|Syntax: .aura #spellid Add the aura from spell #spellid to the selected Unit.|
-|ban account|3|Syntax: .ban account $Name $bantime $reason Ban account kick player. $bantime: negative value leads to permban, otherwise use a timestring like "4d20h3s".|
-|ban character|3|Syntax: .ban character $Name $bantime $reason Ban character and kick player. $bantime: negative value leads to permban, otherwise use a timestring like "4d20h3s".|
-|ban ip|3|Syntax: .ban ip $Ip $bantime $reason Ban IP. $bantime: negative value leads to permban, otherwise use a timestring like "4d20h3s".|
 |ban|3|Syntax: .ban $subcommand Type .ban to see the list of possible subcommands or .help ban $subcommand to see info on subcommands|
+|ban account|3|Syntax: .ban account $account_name $bantime $reason Ban account and kick the player if ingame on any character. $bantime: negative value leads to permban, otherwise use a timestring like `4d20h3s`.|
+|ban playeraccount|3|Syntax: .ban playeraccount $character_name $bantime $reason Ban an account based on the character's name and kick that character if ingame. $bantime: negative value leads to permban, otherwise use a timestring like `4d20h3s`.|
+|ban character|3|Syntax: .ban character $character_name $bantime $reason Ban character and kick that character if ingame. $bantime: negative value leads to permban, otherwise use a timestring like `4d20h3s`.|
+|ban ip|3|Syntax: .ban ip $Ip $bantime $reason Ban IP. $bantime: negative value leads to permban, otherwise use a timestring like `4d20h3s`.|
+|unban account|3|Syntax: .unban account $Name Unban accounts for account name pattern.|
+|unban character|3|Syntax: .unban character $Name Unban accounts for character name pattern.|
+|unban ip|3|Syntax : .unban ip $Ip Unban accounts for IP pattern.|
+|unban|3|Syntax: .unban $subcommand Type .unban to see the list of possible subcommands or .help unban $subcommand to see info on subcommands|
 |baninfo account|3|Syntax: .baninfo account $accountid Watch full information about a specific ban.|
 |baninfo character|3|Syntax: .baninfo character $charactername Watch full information about a specific ban.|
 |baninfo ip|3|Syntax: .baninfo ip $ip Watch full information about a specific ban.|
 |baninfo|3|Syntax: .baninfo $subcommand Type .baninfo to see the list of possible subcommands or .help baninfo $subcommand to see info on subcommands|
-|bank|3|Syntax: .bank Show your bank inventory.|
 |banlist account|3|Syntax: .banlist account [$Name] Searches the banlist for a account name pattern or show full list account bans.|
 |banlist character|3|Syntax: .banlist character $Name Searches the banlist for a character name pattern. Pattern required.|
 |banlist ip|3|Syntax: .banlist ip [$Ip] Searches the banlist for a IP pattern or show full list of IP bans.|
 |banlist|3|Syntax: .banlist $subcommand Type .banlist to see the list of possible subcommands or .help banlist $subcommand to see info on subcommands|
+|bank|3|Syntax: .bank Show your bank inventory.|
 |bindsight|3|Syntax: .bindsight Binds vision to the selected unit indefinitely. Cannot be used while currently possessing a target.|
 |cast back|3|Syntax: .cast back #spellid [triggered] Selected target will cast #spellid to your character. If 'trigered' or part provided then spell casted with triggered flag.|
 |cast dist|3|Syntax: .cast dist #spellid [#dist [triggered]] You will cast spell to pint at distance #dist. If 'trigered' or part provided then spell casted with triggered flag. Not all spells can be casted as area spells.|
@@ -417,10 +422,6 @@ Note: Some commands are working only by selecting a player or a creature. These 
 |ticket viewname|1|Usage: .ticket viewname $creatorname. Returns details about specified ticket. Ticket must be open and not deleted.|
 |ticket|1|Syntax: .ticket $subcommand Type .ticket to see the list of possible subcommands or .help ticket $subcommand to see info on subcommands|
 |unaura|3|Syntax: .unaura #spellid Remove aura due to spell #spellid from the selected Unit.|
-|unban account|3|Syntax: .unban account $Name Unban accounts for account name pattern.|
-|unban character|3|Syntax: .unban character $Name Unban accounts for character name pattern.|
-|unban ip|3|Syntax : .unban ip $Ip Unban accounts for IP pattern.|
-|unban|3|Syntax: .unban $subcommand Type .unban to see the list of possible subcommands or .help unban $subcommand to see info on subcommands|
 |unbindsight|3|Syntax: .unbindsight Removes bound vision. Cannot be used while currently possessing a target.|
 |unfreeze|1|Syntax: .unfreeze (#player) "Unfreezes" #player and enables his chat again. When using this without #name it will unfreeze your target.|
 |unlearn|3|Syntax: .unlearn #spell [all] Unlearn for selected player a spell #spell. If 'all' provided then all ranks unlearned.|
@@ -456,7 +457,6 @@ Note: Some commands are working only by selecting a player or a creature. These 
 |reload lfg_dungeon_rewards|3|Syntax: .reload lfg_dungeon_rewards Reload lfg_dungeon_rewards table.|
 |character changefaction|2|Syntax: .character changefaction $name Change character faction.|
 |character changerace|2|Syntax: .character changerace $name Change character race.|
-|ban playeraccount|3|Syntax: .ban playeraccount $Name $bantime $reason Ban account and kick player. $bantime: negative value leads to permban, otherwise use a timestring like "4d20h3s".|
 |achievement add|4|Syntax: .achievement add $achievement Add an achievement to the targeted player. $achievement: can be either achievement id or achievement link|
 |achievement checkall|3|Syntax: .achievement checkall. Check all achievement criteria of the selected player.|
 |achievement|4|Syntax: .achievement $subcommand Type .achievement to see the list of possible subcommands or .help achievement $subcommand to see info on subcommands|


### PR DESCRIPTION
- Reorganized the ban commands, one was completely off the table, and the unban commands were in alphabetical order but it's not practical to find so I put them near the ban commands. When you look for banning related, everything is there, no need to scroll, better User eXperience.
- Made it clearer that the $bantime does not need double quotes (else it fails)
- Explained the .ban playeraccount command

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
