### PR TITLE
Update Requirements.md

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -85,21 +85,20 @@ After `sudo apt-get update` you can install gcc-7: `sudo apt-get install g++-7 g
 
 ## Mac OS X
 
-Install XCode using the App Store, then open the terminal and type:
+- Install XCode using the App Store, then open the terminal and type:
 
 `xcode-select --install` 
 
-For those who don't have [Homebrew](http://brew.sh/) installed, you can easily install it typing:
+- Install the package manager [Homebrew](http://brew.sh/)
 
-`ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-
-Then use it to install the required packages:
+Use brew it to install the required packages:
 
 `brew update`
 
-`brew install openssl readline cmake ace coreutils bash bash-completion md5sha1sum mysql56`
+`brew install openssl readline cmake ace coreutils bash bash-completion coreutils`
 
-`brew link mysql56 --force`
+`brew link mysql`
+
 
 ## Windows
 

--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -101,7 +101,7 @@ Now install mysql:
 
 `brew install mysql`
 
-You will be prompted some instructions to complete the `mysql` installation, for example to properly set a password. Just follow the instructions and properly configure mysql.
+You will be prompted some instructions to complete the `mysql` installation, for example to properly set a password. Just follow the instructions and properly configure mysql. **This step is important, do not skip it.**
 
 To verify that mysql has been properly installed, try accessing it using either the command line (e.g. `mysql -u root -p`) or using DB client managers with a UI like Sequel Pro.
 

--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -97,7 +97,17 @@ Use brew it to install the required packages:
 
 `brew install openssl readline cmake ace coreutils bash bash-completion coreutils`
 
-`brew link mysql`
+Now install mysql:
+
+`brew install mysql`
+
+You will be prompted some instructions to complete the `mysql` installation, for example to properly set a password. Just follow the instructions and properly configure mysql.
+
+To verify that mysql has been properly installed, try accessing it using either the command line (e.g. `mysql -u root -p`) or using DB client managers with a UI like Sequel Pro.
+
+You can install Sequel Pro with:
+
+`brew cask install sequel-pro`
 
 
 ## Windows


### PR DESCRIPTION
- as the procedure to install `brew` might change, just leave the link to the official website (which is always up to date and very clear about the setup)

- there is no way to force install mysql 5.6, just install `mysql` (currently 8.0)

- add more instructions about correctly completing mysql installation and how to verify it

- fix packages list 