### PR TITLE
chore(requirements): Remove vs17

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -115,7 +115,7 @@ You can install Sequel Ace with:
 
 ## Windows
 
-* Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) version >= 15.9.17 (VS 2017 Community / VS 2019 Community)
+* Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) VS 2019 Community
 
 * Install [CMake](https://cmake.org/) version 2.8 or newer.  
 


### PR DESCRIPTION
seeing https://github.com/azerothcore/azerothcore-wotlk/issues/4096  and others in discord VS17 seems to not work with nodiscard and we should deprecate vs17 anyways. I just cant find where in the core...