### PR TITLE
Fix error when using docker in Windows

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,8 +55,11 @@ google_cse_token:
 # git-wiki includes some internal themes that you can choose
 # check _layouts folder
 #
-markdown: GFM
+markdown: kramdown
 highlighter: rouge
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 
 defaults:
  -
@@ -89,13 +92,22 @@ defaults:
 sass:
     style: compressed
 plugins:
- - jekyll-feed
- - jekyll-redirect-from
- - jekyll-seo-tag
- - jekyll-sitemap
- - jekyll-avatar
- - jemoji
- - jekyll-mentions
+  - jekyll-avatar
+  - jekyll-coffeescript
+  - jekyll-default-layout
+  - jekyll-feed
+  - jekyll-gist
+  - jekyll-paginate
+  - jekyll-mentions
+  - jekyll-optional-front-matter
+  - jekyll-readme-index
+  - jekyll-redirect-from
+  - jekyll-remote-theme
+  - jekyll-relative-links
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jekyll-titles-from-headings
+  - jemoji
 
 exclude: ['wiki']
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When I wanted to build the solution in Windows, I found a series of errors. Which I detail, in the issue below.
Making the proposed changes, the server works, although the links, are obsolete, because they point to /wiki/<>

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/azerothcore/wiki/issues/353

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The idea is to be able to run the server in a crazy way, to make changes and investigate some improvements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Changes were only tested in Windows 10

## Screenshots (if appropriate):
![docker](https://user-images.githubusercontent.com/2810187/104614548-1fcbc400-5667-11eb-867c-79bf388e7891.png)

![localhost](https://user-images.githubusercontent.com/2810187/104614564-22c6b480-5667-11eb-9270-9a239b1d9d63.png)

![errores](https://user-images.githubusercontent.com/2810187/104614758-4ee23580-5667-11eb-9b22-3172f0dec626.png)