### PR TITLE
chore(azerothcore.html): Stop the wiki for generating table of contents

### DIFF
--- a/_layouts/azerothcore.html
+++ b/_layouts/azerothcore.html
@@ -35,8 +35,6 @@
             {% include {{ site.inc_before_toc }} %}
             {% endif %}
             
-            {% include git-wiki/components/toc/toc-lib.html title="Contents:" minHeaders=1 html=content sanitize=true class="inline_toc" id="git-wiki-toc" h_min=1 h_max=3 ordered=1 %}
-            
             {% if site.inc_after_toc %}
             {% include {{ site.inc_after_toc }} %}
             {% endif %}            


### PR DESCRIPTION
closes https://github.com/azerothcore/wiki/issues/267

The sole purpose is to remove the self-generating table of contents which makes some wiki pages look really awful.
However I don't know if removing this line would fix the issue, but after the changes here https://github.com/azerothcore/wiki/pull/379 it is clear that it has something to do with this line as it made it worse in some pages

![image](https://user-images.githubusercontent.com/24550914/104857173-e5884e00-5916-11eb-805a-75d4e67ca3a1.png)
