### PR TITLE
update `h_max` azerothcore.html

### DIFF
--- a/_layouts/azerothcore.html
+++ b/_layouts/azerothcore.html
@@ -35,7 +35,7 @@
             {% include {{ site.inc_before_toc }} %}
             {% endif %}
             
-            {% include git-wiki/components/toc/toc-lib.html title="Contents:" minHeaders=1 html=content sanitize=true class="inline_toc" h_min=1 h_max=3 ordered=1 %}
+            {% include git-wiki/components/toc/toc-lib.html title="Contents:" minHeaders=1 html=content sanitize=true class="inline_toc" h_min=1 h_max=2 ordered=1 %}
             
             {% if site.inc_after_toc %}
             {% include {{ site.inc_after_toc }} %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I suggest reducing the `h_max` from 3 to 2, so that the content is not so extensive. Because otherwise, in certain pages, it becomes very long. Originally, it had that value I think, but I changed it at one point, thinking it was the reason for the error in the `git-wiki-toc` message but luckily, that error was repaired by Yenohal.
