### PR TITLE
Remove ace.dll from list of required dlls in Windows installation instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -114,7 +114,6 @@ You will find your freshly compiled binaries in the Build\bin\Release or Build\b
 You will need the following files in order for the core to function properly:
  
 ```
-ace.dll
 libeay32.dll / libcrypto-1_1.dll / libcrypto-1_1-x64.dll
 libmySQL.dll 
 ssleay32.dll / libssl-1_1.dll / libssl-1_1-x64.dll


### PR DESCRIPTION
## Description
Ace.dll is no longer required to run azerothcore. This PR removes it from the list of required DLLs in the Windows installation instructions.

A recent PR to the Azeroth Core repo, https://github.com/azerothcore/azerothcore-wotlk/pull/3450, removed the need for a separate `ace.dll` file. See [the comment at the bottom of the PR](https://github.com/azerothcore/azerothcore-wotlk/pull/3450#issuecomment-724737882) for a confirmation of this.

## How Has This Been Tested?
* I just upgraded my server to the latest version of AzerothCore, and verified that it can run without `ace.dll`
* @Kitzunu has also tested and confirmed that AzerothCore can run without `ace.dll`
