### PR TITLE
Update Install-with-AC-Dashboard.md

### DIFF
--- a/docs/Install-with-AC-Dashboard.md
+++ b/docs/Install-with-AC-Dashboard.md
@@ -168,7 +168,7 @@ You can create 2 sessions and run the `worldserver` and `authserver` processes i
 
 
 - `tmux new -s auth-session`
-- now run the `./acore.sh run-worldserver` inside it, then detach from it
+- now run the `./acore.sh run-authserver` inside it, then detach from it
 
 You can detach using `CTRL+B+D` to exit the session without killing the process.
 If connected using VSCode SSH, you can just close the terminal session.


### PR DESCRIPTION
Tmux   start World Server was listed twice  fixed auth command under 
the start tmux auth-session section

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
