### PR TITLE
Add info about realmlist in docker guide

### DIFF
--- a/docs/Install-with-Docker.md
+++ b/docs/Install-with-Docker.md
@@ -86,9 +86,19 @@ Docker will build and run your containers. Meanwhile you will see messages like:
 
 **Don't panic**. Your server processes are simply waiting for the database container to be ready, it can take a while (depends on your machine).
 
-Your server will be up and running shortly. 
+Your server will be up and running shortly.
+
+**4) Access database and update realmlist**
+
 To access your MySQL database we recommend clients like [HeidiSQL](https://www.heidisql.com/) (for Windows/Linux+Wine) or [SequelPro](https://www.sequelpro.com/) (for macOS). Use `root` as user and `127.0.0.1` as default host.
 The default password of the root DB user will be `password`.
+
+Unless your server installation is on the same network as your client, you might want to update the `realmlist` address in the `acore_auth` database with your server public IP address :
+```sql
+USE acore_auth;
+SELECT * FROM realmlist;
+UPDATE realmlist SET address='<SERVER PUBLIC IP ADDRESS>';
+```
 
 ## More info
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hello ! If you follow the docker installation guide step by step and your server is not on your local network, you will likely come across this problem where, in the client, you will be able to log in your account but unable to move forward into the realm. It most likely comes from the wrong IP address in acore_auth.realmlist

I think this is a very usefull information for the first time user. Also this information is disclosed in the classic installation guide, step 6, but not in the docker one. So this is what I propose to add in the docker installation guide.

## Related Issue
There are a few issues over the internet related to this, for example : https://stackoverflow.com/questions/54852245/how-to-resolve-sticking-in-realm-selection

Thanks !