### PR TITLE
chore(creature_text): update info

### DIFF
--- a/docs/creature_text.md
+++ b/docs/creature_text.md
@@ -142,6 +142,8 @@ Value from [Languages.dbc](Languages) (+ the wiki table from the dbc file). When
 
 A value from 1-100 that represents the percentage chance that this text will be executed.
 
+Value must be >=0. If the value does not meet the condition the SQL will fail on `creature_text_chk_1`.
+
 ### Emote
 
 The emote that the creature plays when the text is executed. Value to use in this field can be obtained from the [emote.dbc](Emotes)


### PR DESCRIPTION
azerothcore/azerothcore-wotlk#4929

Was always these restrictions with float unsigned, but with the changes in the PR above to CHECH (col>=0) the SQL will give a different error.