### PR TITLE
chore(spell_enchant_proc_data): update info

### DIFF
--- a/docs/spell_enchant_proc_data.md
+++ b/docs/spell_enchant_proc_data.md
@@ -32,7 +32,7 @@ Enchantment ID from SpellItemEnchantment.dbc
 
 ### PPMChance
 
-`field-no-description|3`
+Value must be >=0. If the value does not meet the condition the SQL will fail on `spell_enchant_proc_data_chk_1`.
 
 ### procEx
 


### PR DESCRIPTION
azerothcore/azerothcore-wotlk#4929

Was always these restrictions with float unsigned, but with the changes in the PR above to CHECH (col>=0) the SQL will give a different error.