### PR TITLE
Update Requirements.md

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -4,7 +4,13 @@
 
 ### Debian-based requirements
 
-#### Ubuntu
+#### Ubuntu with MariaDB 10.x
+
+```sh
+sudo apt update && sudo apt full-upgrade -y && sudo apt install git cmake make gcc g++ clang libssl-dev libbz2-dev libreadline-dev libncurses-dev libace-6.* libace-dev mariadb-server mariadb-client libmariadb-dev libmariadbclient-dev libmariadb-dev-compat
+```
+
+#### Ubuntu with MySQL 8.x
 
 ```sh
 sudo apt-get update && sudo apt-get install git cmake make gcc g++ clang libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev mysql-server libace-6.* libace-dev


### PR DESCRIPTION
Ubuntu installation with seperate MariaDB and Oracle MySQL

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added sperate instructions for MariaDB and Oracle MySQL

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no manual how to user MariaDB instead Oracle MySQL

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested with AC https://github.com/azerothcore/azerothcore-wotlk/commit/cde067390f9e7bc884361174cde882ae4cedfcd6
- tested on Ubuntu 20.04 with LXD
- package installation → setup DB and users → source download → compile → import databases with db_assambler → run authserver and worldserver → log in and play


## Screenshots (if appropriate):
