### PR TITLE
Directions for installing modules while using Docker.

### DIFF
--- a/docs/Install-with-Docker.md
+++ b/docs/Install-with-Docker.md
@@ -105,11 +105,22 @@ UPDATE realmlist SET address='<SERVER PUBLIC IP ADDRESS>';
 
 To add a module simply place the module directory inside of the **/azeorthcore-wotlk/modules** directory.
 
-After adding a module you'll have to rebuild the server.
+After adding a module you'll have to rebuild azerothcore.
 ```
 ./bin/acore-docker-build
 ```
-If the added module makes use of configurations files you'll have to place them in the **azerothcore-wotlk\docker\worldserver\etc\modules** directory. You'll have to manually create the modules directory if it doesn't exist.
+If the added module makes use of configurations files you'll have to place them in the **azerothcore-wotlk\docker\worldserver\etc\modules** directory. If the module directory doesn't exist, you'll have to manually create it yourself.
+
+After rebulding you can start the containers again with the docker-compose command.
+
+(if your containers are still running)
+```
+docker-compose restart
+```
+or (if your containers are stopped)
+```
+docker-compose start
+```
 
 ### Memory usage
 

--- a/docs/Install-with-Docker.md
+++ b/docs/Install-with-Docker.md
@@ -101,6 +101,15 @@ UPDATE realmlist SET address='<SERVER PUBLIC IP ADDRESS>';
 ```
 
 ## More info
+### Adding Modules
+
+Adding a module to your server is quite simple, place the module in the module directory of your server (e.g. /azerothcore-wotlk/modules)
+
+After adding a module you'll have to rebuild the server.
+```
+./bin/acore-docker-build
+```
+If the added module makes use of configurations file you'll have to place them in the **azerothcore-wotlk\docker\worldserver\etc\modules** directory. You'll have to manually create the modules directory if it doesn't exist.
 
 ### Memory usage
 

--- a/docs/Install-with-Docker.md
+++ b/docs/Install-with-Docker.md
@@ -103,13 +103,13 @@ UPDATE realmlist SET address='<SERVER PUBLIC IP ADDRESS>';
 ## More info
 ### Adding Modules
 
-Adding a module to your server is quite simple, place the module in the module directory of your server (e.g. /azerothcore-wotlk/modules)
+To add a module simply place the module directory inside of the **/azeorthcore-wotlk/modules** directory.
 
 After adding a module you'll have to rebuild the server.
 ```
 ./bin/acore-docker-build
 ```
-If the added module makes use of configurations file you'll have to place them in the **azerothcore-wotlk\docker\worldserver\etc\modules** directory. You'll have to manually create the modules directory if it doesn't exist.
+If the added module makes use of configurations files you'll have to place them in the **azerothcore-wotlk\docker\worldserver\etc\modules** directory. You'll have to manually create the modules directory if it doesn't exist.
 
 ### Memory usage
 

--- a/docs/Install-with-Docker.md
+++ b/docs/Install-with-Docker.md
@@ -111,13 +111,13 @@ After adding a module you'll have to rebuild azerothcore.
 ```
 If the added module makes use of configurations files you'll have to place them in the **azerothcore-wotlk\docker\worldserver\etc\modules** directory. If the module directory doesn't exist, you'll have to manually create it yourself.
 
-After rebulding you can start the containers again with the docker-compose command.
+After rebuilding you can (re)start the containers again with the docker-compose command.
 
-(if your containers are still running)
+If your containers are running, please use the restart command
 ```
 docker-compose restart
 ```
-or (if your containers are stopped)
+or if your containers are stopped, use the start command
 ```
 docker-compose start
 ```


### PR DESCRIPTION

Fixes #276 

## Description
Simple instructions for adding a module while using docker containers for AzerothCore + where to place configuration files.


## Motivation and Context
A simple but useful addition, especially since it also tells you where to place the configuration files, which was confusing for me personally.


