### PR TITLE
Add documentation for areaId and zoneId

### DIFF
--- a/docs/creature.md
+++ b/docs/creature.md
@@ -8,47 +8,51 @@ Contains individual creature spawn data for each individual spawn of each indivi
 
 | Field                 | Type         | Attributes | Key | Null | Default | Extra          | Comment                                                                               |
 |-----------------------|--------------|------------|-----|------|---------|----------------|---------------------------------------------------------------------------------------|
-| [guid][1]             | INT      | UNSIGNED   | PRI | NO   | NULL    | Auto Increment | Global Unique Identifier                                                              |
-| [id][2]               | MEDIUMINT | UNSIGNED   |     | NO   | 0       |                | Creature Identifier                                                                   |
-| [map][3]              | SMALLINT  | UNSIGNED   |     | NO   | 0       |                | Map Identifier                                                                        |
-| [spawnMask][4]        | TINYINT   | UNSIGNED   |     | NO   | 1       |                |                                                                                       |
-| [phaseMask][5]        | SMALLINT  | UNSIGNED   |     | NO   | 1       |                |                                                                                       |
-| [modelid][6]          | MEDIUMINT | UNSIGNED   |     | NO   | 0       |                | 0 core determined random model or model_id to prevent random model selection by core. |
-| [equipment_id][7]     | TINYINT   | UNSIGNED   |     | NO   | 1       |                |                                                                                       |
-| [position_x][8]       | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
-| [position_y][9]       | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
-| [position_z][10]      | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
-| [orientation][11]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
-| [spawntimesecs][12]   | INT      | UNSIGNED   |     | NO   | 120     |                |                                                                                       |
-| [wander_distance][13] | FLOAT        | SIGNED     |     | NO   | 5       |                | Dist in yards for random movement.                                                    |
-| [currentwaypoint][14] | MEDIUMINT | UNSIGNED   |     | NO   | 0       |                | Storage used by core. "Always set as 0"                                               |
-| [curhealth][15]       | INT      | UNSIGNED   |     | NO   | 1       |                | Storage used by core. "Always set as 1"                                               |
-| [curmana][16]         | INT      | UNSIGNED   |     | NO   | 0       |                | Storage used by core. "Always set as 0"                                               |
-| [MovementType][17]    | TINYINT   | UNSIGNED   |     | NO   | 0       |                | 0 No movement, 1 random, 2 path                                                       |
-| [npcflag][18]         | INT      | UNSIGNED   |     | NO   | 0       |                |                                                                                       |
-| [unit_flags][19]      | INT      | UNSIGNED   |     | NO   | 0       |                |                                                                                       |
-| [dynamicflags][20]    | INT      | UNSIGNED   |     | NO   | 0       |                |                                                                                       |
+| [guid][1]             | INT          | UNSIGNED   | PRI | NO   | NULL    | Auto Increment | Global Unique Identifier                                                              |
+| [id][2]               | MEDIUMINT    | UNSIGNED   |     | NO   | 0       |                | Creature Identifier                                                                   |
+| [map][3]              | SMALLINT     | UNSIGNED   |     | NO   | 0       |                | Map Identifier                                                                        |
+| [zoneId][4]           | SMALLINT     | UNSIGNED   |     | NO   | 0       |                | Zone Identifier                                                                       |
+| [areaId][5]           | SMALLINT     | UNSIGNED   |     | NO   | 0       |                | Area Identifier                                                                       |
+| [spawnMask][6]        | TINYINT      | UNSIGNED   |     | NO   | 1       |                |                                                                                       |
+| [phaseMask][7]        | SMALLINT     | UNSIGNED   |     | NO   | 1       |                |                                                                                       |
+| [modelid][8]          | MEDIUMINT    | UNSIGNED   |     | NO   | 0       |                | 0 core determined random model or model_id to prevent random model selection by core. |
+| [equipment_id][9]     | TINYINT      | UNSIGNED   |     | NO   | 1       |                |                                                                                       |
+| [position_x][10]      | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
+| [position_y][11]      | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
+| [position_z][12]      | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
+| [orientation][13]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                                                                                       |
+| [spawntimesecs][14]   | INT          | UNSIGNED   |     | NO   | 120     |                |                                                                                       |
+| [wander_distance][15] | FLOAT        | SIGNED     |     | NO   | 5       |                | Dist in yards for random movement.                                                    |
+| [currentwaypoint][16] | MEDIUMINT    | UNSIGNED   |     | NO   | 0       |                | Storage used by core. "Always set as 0"                                               |
+| [curhealth][17]       | INT          | UNSIGNED   |     | NO   | 1       |                | Storage used by core. "Always set as 1"                                               |
+| [curmana][18]         | INT          | UNSIGNED   |     | NO   | 0       |                | Storage used by core. "Always set as 0"                                               |
+| [MovementType][19]    | TINYINT      | UNSIGNED   |     | NO   | 0       |                | 0 No movement, 1 random, 2 path                                                       |
+| [npcflag][20]         | INT          | UNSIGNED   |     | NO   | 0       |                |                                                                                       |
+| [unit_flags][21]      | INT          | UNSIGNED   |     | NO   | 0       |                |                                                                                       |
+| [dynamicflags][22]    | INT          | UNSIGNED   |     | NO   | 0       |                |                                                                                       |
 
 [1]: #guid
 [2]: #id
 [3]: #map
-[4]: #spawnmask
-[5]: #phasemask
-[6]: #modelid
-[7]: #equipment_id
-[8]: #position_x
-[9]: #position_y
-[10]: #position_z
-[11]: #orientation
-[12]: #spawntimesecs
-[13]: #wander_distance
-[14]: #currentwaypoint
-[15]: #curhealth
-[16]: #curmana
-[17]: #movementtype
-[18]: #npcflag
-[19]: #unit_flags
-[20]: #dynamicflags
+[4]: #zoneId
+[5]: #areaId
+[6]: #spawnmask
+[7]: #phasemask
+[8]: #modelid
+[9]: #equipment_id
+[10]: #position_x
+[11]: #position_y
+[12]: #position_z
+[13]: #orientation
+[14]: #spawntimesecs
+[15]: #wander_distance
+[16]: #currentwaypoint
+[17]: #curhealth
+[18]: #curmana
+[19]: #movementtype
+[20]: #npcflag
+[21]: #unit_flags
+[22]: #dynamicflags
 
 **Field Descriptions**
 
@@ -64,9 +68,21 @@ The ID of the [template](creature_template#creature_template-entry) that is used
 
 The ID of the [map](Map) that the creature is spawned on.
 
+### zoneId
+
+The ID of the zone that the creature is spawned in. (e.g. The Barrens)
+
+This column is filled in by the worldserver on startup if the `Calculate.Creature.Zone.Area.Data` setting is enabled. It originates from AreaTable.dbc.
+
+### areaId
+
+The ID of the area that the creature is spawned in. You can think of an area as a "subzone" of a zone, e.g. Lushwater Oasis inside The Barrens. 
+
+This column is filled in by the worldserver on startup if the `Calculate.Creature.Zone.Area.Data` setting is enabled. It originates from AreaTable.dbc.
+
 ### spawnMask
 
-Controls under which difficulties the creature is spawned. The values are bit-masked, so you can add them together to combine the affects of two or more values.
+Controls under which difficulties the creature is spawned. The values are bit-masked, so you can add them together to combine the effects of two or more values.
 
 Example:
 

--- a/docs/gameobject.md
+++ b/docs/gameobject.md
@@ -10,39 +10,43 @@ This table holds the individual object data on each spawned game object in the w
 
 | Field               | Type         | Attributes | Key | Null | Default | Extra          | Comment                  |
 |---------------------|--------------|------------|-----|------|---------|----------------|--------------------------|
-| [guid][1]           | INT      | UNSIGNED   | PRI | NO   | NULL    | Auto increment | Global Unique Identifier |
-| [id][2]             | MEDIUMINT | UNSIGNED   |     | NO   | 0       |                | Gameobject Identifier    |
-| [map][3]            | SMALLINT  | UNSIGNED   |     | NO   | 0       |                | Map Identifier           |
-| [spawnMask][4]      | TINYINT   | UNSIGNED   |     | NO   | 1       |                |                          |
-| [phaseMask][5]      | SMALLINT  | UNSIGNED   |     | NO   | 1       |                |                          |
-| [position_x][6]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [position_y][7]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [position_z][8]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [orientation][9]    | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [rotation0][10]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [rotation1][11]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [rotation2][12]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [rotation3][13]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
-| [spawntimesecs][14] | INT      | SIGNED     |     | NO   | 0       |                |                          |
-| [animprogress][15]  | TINYINT   | UNSIGNED   |     | NO   | 0       |                |                          |
-| [state][16]         | TINYINT   | UNSIGNED   |     | NO   | 1       |                |                          |
+| [guid][1]           | INT          | UNSIGNED   | PRI | NO   | NULL    | Auto increment | Global Unique Identifier |
+| [id][2]             | MEDIUMINT    | UNSIGNED   |     | NO   | 0       |                | Gameobject Identifier    |
+| [map][3]            | SMALLINT     | UNSIGNED   |     | NO   | 0       |                | Map Identifier           |
+| [zoneId][4]         | SMALLINT     | UNSIGNED   |     | NO   | 0       |                | Zone Identifier          |
+| [areaId][5]         | SMALLINT     | UNSIGNED   |     | NO   | 0       |                | Area Identifier          |
+| [spawnMask][6]      | TINYINT      | UNSIGNED   |     | NO   | 1       |                |                          |
+| [phaseMask][7]      | SMALLINT     | UNSIGNED   |     | NO   | 1       |                |                          |
+| [position_x][8]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [position_y][9]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [position_z][10]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [orientation][11]    | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [rotation0][12]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [rotation1][13]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [rotation2][14]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [rotation3][15]     | FLOAT        | SIGNED     |     | NO   | 0       |                |                          |
+| [spawntimesecs][16] | INT          | SIGNED     |     | NO   | 0       |                |                          |
+| [animprogress][17]  | TINYINT      | UNSIGNED   |     | NO   | 0       |                |                          |
+| [state][18]         | TINYINT      | UNSIGNED   |     | NO   | 1       |                |                          |
 
 [1]: #guid
 [2]: #id
 [3]: #map
-[4]: #spawnmask
-[5]: #phasemask
-[6]: #position_x
-[7]: #position_y
-[8]: #position_z
-[9]: #orientation
-[10]: #rotation0
-[11]: #rotation1
-[12]: #rotation2
-[13]: #rotation3
-[14]: #spawntimesecs
-[15]: #animprogress
-[16]: #state
+[4]: #zoneId
+[5]: #areaId
+[6]: #spawnmask
+[7]: #phasemask
+[8]: #position_x
+[9]: #position_y
+[10]: #position_z
+[11]: #orientation
+[12]: #rotation0
+[13]: #rotation1
+[14]: #rotation2
+[15]: #rotation3
+[16]: #spawntimesecs
+[17]: #animprogress
+[18]: #state
 
 **Description of the fields**
 
@@ -57,6 +61,18 @@ The template ID of the gameobject. See [gameobject\_template.entry](http://www.a
 ### map
 
 The map ID where this object is spawned. See Maps.dbc
+
+### zoneId
+
+The ID of the zone that this object is spawned in. (e.g. The Barrens)
+
+This column is filled in by the worldserver on startup if the `Calculate.Gameoject.Zone.Area.Data` setting is enabled. It originates from AreaTable.dbc.
+
+### areaId
+
+The ID of the area that this object is spawned in. You can think of an area as a "subzone" of a zone, e.g. Lushwater Oasis inside The Barrens. 
+
+This column is filled in by the worldserver on startup if the `Calculate.Gameoject.Zone.Area.Data` setting is enabled. It originates from AreaTable.dbc.
 
 ### spawnMask
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added documentation for the `areaId` and `zoneId` columns in the `creature` and `gameobject` pages

## Description
<!--- Describe your changes in detail -->
Describe what areaId and zoneId are and how these columns are populated

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #512

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I know these columns are useless from the core's perspective but I actually found them useful while working on azerothcore/azerothcore-wotlk#6088. I would have found a solution more easily if documentation for these columns had been available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Could not get either installation method to work lmao so I just copied the entire markdown into an online markdown editor thing to inspect them

## Screenshots (if appropriate):
