### PR TITLE
Lots of spelling, formatting, dead/broken links fixed, better documenting options, more universal CLI

### DIFF
--- a/.env-files/Gemfile.github
+++ b/.env-files/Gemfile.github
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'webrick' # solves error with Ruby 3.0
 gem "jekyll-gitlab-metadata" # for cross compatibility

--- a/.env-files/Gemfile.github
+++ b/.env-files/Gemfile.github
@@ -1,3 +1,4 @@
 source 'http://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'webrick' # solves error with Ruby 3.0
 gem "jekyll-gitlab-metadata" # for cross compatibility

--- a/.env-files/Gemfile.gitlab
+++ b/.env-files/Gemfile.gitlab
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem "jekyll-avatar"
 gem "jekyll-coffeescript"
 gem "jekyll-default-layout"

--- a/.env-files/Gemfile.gitlab
+++ b/.env-files/Gemfile.gitlab
@@ -16,3 +16,4 @@ gem "jekyll-sitemap"
 gem "jekyll-titles-from-headings"
 gem "jemoji"
 gem "jekyll-gitlab-metadata"
+gem 'webrick' # solves error with Ruby 3.0

--- a/.github/linters/markdown-lint.yml
+++ b/.github/linters/markdown-lint.yml
@@ -1,0 +1,12 @@
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 400            # Line length 80 is far to short
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+
+blank_lines: false  # Error on blank lines

--- a/_config.yml
+++ b/_config.yml
@@ -99,13 +99,13 @@ defaults:
 sass:
     style: compressed
 plugins:
- - jekyll-feed
- - jekyll-redirect-from
- - jekyll-seo-tag
- - jekyll-sitemap
- - jekyll-avatar
- - jemoji
- - jekyll-mentions
+  - jekyll-feed
+  - jekyll-redirect-from
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jekyll-avatar
+  - jemoji
+  - jekyll-mentions
 
 exclude: ['wiki']
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,21 @@ services:
       context: .
       dockerfile: .env-files/Dockerfile.github
     ports:
-     - 4000:4000
-     - 35729:35729
+     - "4000:4000/tcp"
+     - "35729:35729/tcp"
     environment: 
      - BUNDLE_GEMFILE=.env-files/Gemfile.github
     volumes:
      - .:/srv/jekyll
      - github_site:/srv/jekyll/_site
-    command: bundle exec jekyll serve --host 0.0.0.0 --force_polling --livereload
+    command: 'bundle exec jekyll serve --host 0.0.0.0 --force_polling --livereload'
   gitlab-wiki-theme:
     build: 
       context: .
       dockerfile: .env-files/Dockerfile.gitlab
     ports:
-      - 4000:4000
-      - 35729:35729
+      - "4000:4000/tcp"
+      - "35729:35729/tcp"
     environment: 
      - BUNDLE_GEMFILE=.env-files/Gemfile.gitlab
     volumes:

--- a/docs/cmake-options.md
+++ b/docs/cmake-options.md
@@ -18,7 +18,7 @@ Note: Will be CPU intensive.
 
 ## PCH
 
-Totally disable PCH:
+Disable all usage of precompiled headers:
 
 `-DNOPCH=1`
 
@@ -27,6 +27,8 @@ Or one by one:
 -DUSE_COREPCH=0
 -DUSE_SCRIPTPCH=0
 ```
+
+May increase build times.
 
 ## VERBOSITY
 

--- a/docs/cmake-options.md
+++ b/docs/cmake-options.md
@@ -6,11 +6,15 @@ redirect_from: "/CMake-options"
 
 ## PERFORMANCE
 
-If you want to disable performance improvement, add this flag `-DENABLE_EXTRAS=0`
+If you want to disable performance optimizations, add this flag: `-DENABLE_EXTRAS=0`
+
+Only necessary if you're debugging.
 
 ## EXTRA LOGS
 
-If you want to enable extra logs, add this flag: `-DENABLE_EXTRAS=1 -DENABLE_EXTRA_LOGS=1`
+If you want to enable extra verbose logs, add this flag: `-DENABLE_EXTRA_LOGS=1`
+
+Note: Will be CPU intensive.
 
 ## PCH
 
@@ -24,9 +28,13 @@ Or one by one:
 -DUSE_SCRIPTPCH=0
 ```
 
+## VERBOSITY
+
+Enable all warnings when compiling: `-DWITH_WARNINGS=1`
+
 ## OTHER OPTIONS
 
 Other options are available here:
 
-* https://github.com/azerothcore/azerothcore-wotlk/blob/master/conf/config.cmake.dist
+* https://github.com/azerothcore/azerothcore-wotlk/blob/master/conf/dist/config.cmake#L58
 * https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/cmake/showoptions.cmake

--- a/docs/common-errors.md
+++ b/docs/common-errors.md
@@ -52,7 +52,7 @@ This can mean several things:
 
 ## Database Update-related errors
 
-**ACE00020** My DB Assambler closes and does not import all updates, I get:
+**ACE00020** My DB Assembler closes and does not import all updates, I get:
 ```
 ERROR 1054 (42522) at line 14062: Unknown column 'resistance2' in 'field list'
 ```
@@ -62,16 +62,16 @@ The easiest way to fix it is by dropping your database and importing it again.
 
 ---------------------------------------------------------
 
-**ACE0021** My DB Assambler closes and does not import all updates, I get:
+**ACE0021** My DB Assembler closes and does not import all updates, I get:
 
 This can be due to several reasons:
 
-1. You have the wrong credentials set up for the DB Assambler.
+1. You have the wrong credentials set up for the DB Assembler.
 2. Your Database structure has been modified manually and is conflicting with the updates. Fix this by dropping the database.
 
 ---------------------------------------------------------
 
-**ACE00022** My DB Assambler closes and does not import all updates, I get:
+**ACE00022** My DB Assembler closes and does not import all updates, I get:
 ```
 ERROR 1067 (42000) at line 181: Invalid default value for 'start_time'.
 ```
@@ -140,11 +140,11 @@ You need to use the exact version of libmysql.dll as the version you used to com
 
 **ACE00060** I don't get a AzerothCore hash
 
-Read how to properly install Git for Windows.
+Reinstall Git for Windows and make sure you select "Git from the command line and also 3rd party software" when asked about adjusting your PATH.
 
 ---------------------------------------------------------
 
-**ACE00061** I cannot install AzerothCore on CentOS/Ubtuntu/Debian etc.
+**ACE00061** I cannot install AzerothCore on CentOS/Ubuntu/Debian etc.
 
 AzerothCore requires GCC 8.0 or higher and CLang 7 or higher.
 
@@ -161,7 +161,7 @@ AzerothCore requires [Visual Studio 2019](https://docs.microsoft.com/en-us/visua
 c++: internal compiler error: Segmentation fault (program cc1plus)
 ```
 This can be due to:
-1. Selinux stronged kernels, workaround: change to one standard kernel, compile with clang instad of gcc or compile without pch.
+1. SELinux hardened kernels, workaround: change to one standard kernel, compile with clang instead of gcc or compile without pch.
 2. Low ram/swap memory, increase it.
 
 ---------------------------------------------------------
@@ -172,12 +172,12 @@ Use google or buy a book to learn the operating system you are using.
 
 ---------------------------------------------------------
 
-**ACE00065** I can't copmile, I get:
+**ACE00065** I can't compile, I get:
 ```
 fatal error C1060: compiler is out of heap space
 C1076: compiler limit : internal heap limit reached; use /Zm to specify a higher limit
 ```
-Read [How to: Enable a 64-Bit, x664 hosted MSVC toolset on the command line. Microsoft](https://docs.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?redirectedfrom=MSDN&view=msvc-160).
+Read [How to: Enable a 64-Bit, x64 hosted MSVC toolset on the command line. Microsoft](https://docs.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?redirectedfrom=MSDN&view=msvc-160).
 
 ---------------------------------------------------------
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -6,17 +6,17 @@ redirect_from: "/Contribute"
 
 You can contribute in several ways to AzerothCore:
 
-- [commenting an open issue](Contribute#how-to-comment-an-issue)
+- [commenting an open issue](contribute#how-to-comment-an-issue)
 
-- [opening an issue](Contribute#how-to-open-an-issue)
+- [opening an issue](contribute#how-to-open-an-issue)
 
 - [testing a pull request](How-to-test-a-PR)
 
 - [testing DB-only changes](How-to-test-DB-only-changes)
 
-- [creating a pull request](Contribute#how-to-create-a-pull-request)
+- [creating a pull request](contribute#how-to-create-a-pull-request)
 
-- [improving our wiki](Contribute#improve-the-wiki)
+- [improving our wiki](contribute#improve-the-wiki)
 ## General information
 
 To contribute, you obviously need a github account.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially-supported and complete ways of installing AzerothCore, for any purposes.
 
-- [**Azerothcore Classic Setup**](#azerothcore-classic-setup) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purposes. This process gives more awareness of how AzerothCore is structured. See below in this page.
+- [Azerothcore Classic Setup (Windows, Linux, macOS)](#azerothcore-classic-setup) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purposes. This process gives more awareness of how AzerothCore is structured. See below in this page.
 
 - [Docker setup](install-with-docker.md) - a simplified installation process based on Docker.
 

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -62,10 +62,16 @@ At this point, you must be in your "build/" directory.
 echo $HOME
 ```
 
-**Note**: in case you use a non-default package for `clang`, you need to replace it accordingly. For example, if you installed `clang-6.0` then you have to replace `clang` with `clang-6.0` and `clang++` with `clang++-6.0`
+**Note**: in case you use a non-default package for `clang` (such as not from a package manager), you need to replace it accordingly with the path of where your clang and clang++.
 
 ```sh
-cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_WARNINGS=1 -DTOOLS=0 -DSCRIPTS=static
+cmake ../ \
+-DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ \
+-DCMAKE_C_COMPILER=(which clang) \
+-DCMAKE_CXX_COMPILER=(which clang++) \
+-DWITH_WARNINGS=1 \
+-DTOOLS=1 \
+-DSCRIPTS=static
 ```
 
 To know the amount of cores available.

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -81,10 +81,10 @@ You can use the following command
 nproc --all
 ```
 
-Then, replacing `6` with the number of threads that you want to execute, type:
+Then you can simply run this to compile with all threads available and install the server.
 
 ```sh
-make -j 6
+make -j$(nproc --all)
 make install
 ```
 

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -62,13 +62,13 @@ At this point, you must be in your "build/" directory.
 echo $HOME
 ```
 
-**Note**: in case you use a non-default package for `clang` (such as not from a package manager), you need to replace it accordingly with the path of where your clang and clang++.
+**Note**: in case you use a non-default package for `clang` (such as not from a package manager), you may need to replace the binary name accordingly with the path of where your clang and clang++. This is usually not necessary as long as  you installed from a package manager as they symlink the binary names with the common paths.
 
 ```sh
 cmake ../ \
--DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ \
--DCMAKE_C_COMPILER=(which clang) \
--DCMAKE_CXX_COMPILER=(which clang++) \
+-DCMAKE_INSTALL_PREFIX=$(dirname "$(pwd)") \
+-DCMAKE_C_COMPILER=$(which clang) \
+-DCMAKE_CXX_COMPILER=$(which clang++) \
 -DWITH_WARNINGS=1 \
 -DTOOLS=1 \
 -DSCRIPTS=static

--- a/docs/linux-keeping-the-server-up-to-date.md
+++ b/docs/linux-keeping-the-server-up-to-date.md
@@ -7,17 +7,20 @@
 
 ## Keeping the source Up-to-Date
 
+In your cloned folder, pull from master to get any new changes made from the repo.
+
 ```sh
-cd ~/azerothcore/
 git pull origin master
 ```
 
+Rebuild if new changes were pulled.
+
 ```sh
 cd build
-make -j 8; make install
+make -j$(nproc --all) && make install
 ```
 
-Sometimes we add or remove files from the repositiory. At that point it is neccessary to recompile the server, the same way as it was installed the first time [in the Linux Core Installation](linux-core-installation.md#configuring-for-compiling).
+Sometimes we add or remove files from the repository. At that point it is necessary to recompile the server, the same way as it was installed the first time [in the Linux Core Installation](linux-core-installation.md#configuring-for-compiling).
 
 ## Keeping the Database Up-to-Date
 

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -50,19 +50,18 @@ cd build
 
 ### Configuring for compiling
 
-Before running the CMake command, replace `$HOME/azeroth-server/` with the path of the server installation (where you want to place the compiled binaries).
-
 Parameter explanation for advanced users [CMake options](cmake-options.md).
 
 At this point, you must be in your "build/" directory.
 
-**Note**: in the follows command the variable `$HOME` is the path of the **current user**, so if you are logged as root, $HOME will be "/root".
+**Note**: in the follows command the variable `$HOME` is the home directory of the **current user**, so if you are logged as root, $HOME will be "/root".
 
 ```sh
 cmake ../ \
--DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/  \
--DTOOLS=0 \
+-DCMAKE_INSTALL_PREFIX=$(dirname "$(pwd)")  \
+-DTOOLS=1 \
 -DSCRIPTS=static \
+-DWITH_WARNINGS=1 \
 -DMYSQL_ADD_INCLUDE_PATH=/usr/local/include \
 -DMYSQL_LIBRARY=/usr/local/lib/libmysqlclient.dylib \
 -DREADLINE_INCLUDE_DIR=/usr/local/opt/readline/include \
@@ -72,17 +71,17 @@ cmake ../ \
 -DOPENSSL_CRYPTO_LIBRARIES=/usr/local/opt/openssl/lib/libcrypto.dylib
 ```
 
-To know the amount of cores available.
-You can use the following command
+To know the amount of threads available.
+You can use the following command:
 
 ```sh
 nproc --all
 ```
 
-Then, replacing `4` with the number of threads that you want to execute, type:
+Then you can simply run this to compile with all threads available and install the server.
 
 ```sh
-make -j 4
+make -j$(nproc --all)
 make install
 ```
 

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -11,8 +11,7 @@ See [Requirements](requirements.md) before you continue.
 
 ## Getting the source code
 
-Choose **ONE** of the following method, run one of the below `git ...` commands in your terminal.
-
+Choose **ONE** of the following methods. Run one of the below `git ...` commands in your terminal.
 
 1. Clone only the master branch + full history (smaller size - recommended):
 
@@ -20,7 +19,7 @@ Choose **ONE** of the following method, run one of the below `git ...` commands 
     git clone https://github.com/azerothcore/azerothcore-wotlk.git --branch master --single-branch azerothcore
     ```
 
-1. Clone only the master branch + no previous history (smallest size):
+2. Clone only the master branch + no previous history (smallest size):
 
     ```sh
     git clone https://github.com/azerothcore/azerothcore-wotlk.git --branch master --single-branch azerothcore --depth 1
@@ -28,7 +27,7 @@ Choose **ONE** of the following method, run one of the below `git ...` commands 
 
     Note: If you want to get the full history back, use `git fetch --unshallow`.
 
-1. Clone all branches and all history:
+3. Clone all branches and all history:
 
     ```sh
     git clone https://github.com/azerothcore/azerothcore-wotlk.git azerothcore
@@ -53,8 +52,6 @@ cd build
 Parameter explanation for advanced users [CMake options](cmake-options.md).
 
 At this point, you must be in your "build/" directory.
-
-**Note**: in the follows command the variable `$HOME` is the home directory of the **current user**, so if you are logged as root, $HOME will be "/root".
 
 ```sh
 cmake ../ \

--- a/docs/macos-keeping-the-server-up-to-date.md
+++ b/docs/macos-keeping-the-server-up-to-date.md
@@ -8,13 +8,14 @@
 ## Keeping the source Up-to-Date
 
 ```sh
-cd ~/azerothcore/
 git pull origin master
 ```
 
+Rebuild if new changes were pulled.
+
 ```sh
 cd build
-make -j 8; make install
+make -j$(nproc --all) && make install
 ```
 
 Sometimes we add or remove files from the repositiory. At that point it is neccessary to recompile the server, the same way as it was installed the first time [in the macOS Core Installation](macos-core-installation.md#configuring-for-compiling).

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -5,7 +5,7 @@
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
 | [<< Step 2: Core Installation](core-installation.md) | [Step 4: Database Installation >>](database-installation.md) |
 
-Now that you have the source compiled, you need to add some neccessary files, by either downloading or extracting them.
+Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
 
 Some files are optional but highly recommended:
 
@@ -21,7 +21,7 @@ If you do not want to extract these files using the extractors you can find down
 
 Github link:
 
-[Full data (v10) - from 05/04/2021 to now](https://github.com/wowgaming/client-data/releases/){target="_blank"} (Used in the automatic downloader script in `/apps/`)
+[Full data (v10) - from 05/04/2021 to now](https://github.com/wowgaming/client-data/releases/) (Used in the automatic downloader script in `/apps/`)
 
 Mega link:
 
@@ -31,7 +31,7 @@ Mega link:
 
 If you downloaded the files above you can skip this step and jump forward to [worldserver.conf / authserver.conf](#worldserverconf--authserverconf).
 
-This part is just a general summary of the overall process - please read it more detaild for the OS you are working with.
+This part is just a general summary of the overall process - please read it more detailed for the OS you are working with.
 
 [Linux Server Setup](linux-server-setup.md)
 
@@ -45,7 +45,7 @@ By default you will compile your core with tools and you will get the following 
 
 Place the files with your World of Warcraft binary (wow.exe on windows) and run them.
 
-After extracting all neccessary files, create a folder called **Data** within the **RelWithDebInfo** or **Debug** directory and place the files in there. Alternatively you can specify directory where you want to keep them changing DataDir value in worldserver.conf file.
+After extracting all necessary files, create a folder called **Data** within the **RelWithDebInfo** or **Debug** directory and place the files in there. Alternatively you can specify directory where you want to keep them changing DataDir value in worldserver.conf file.
 
 If you use extractors from other projects or branches it is almost certain that your AzerothCore will not recognize the extracted data or even work!
 

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -131,7 +131,7 @@ There are three DLL files that need to be manually added to this folder, and you
 
 *Note: You need the exact version of libmysql to correspond to the MySQL you have downloaded. Due to this you cannot download the DLL from the web and need to take it out of the folder.*
 
-OpenSLL _before_ version 1.1.0:
+OpenSSL _before_ version 1.1.0:
 
 **libeay32.dll**
 **ssleay32.dll** → C:\OpenSSL-Win64\ or C:\OpenSSL-Win32\ *(depends on if your core is 64-bit or 32-bit)*.

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -9,7 +9,7 @@
 | :- |
 | Boost ≥ 1.70 - 1.74 |
 | MySQL ≥ 5.7.0 |
-| OpenSLL ≥ 1.0.x |
+| OpenSSL ≥ 1.0.x |
 | CMake ≥ 3.16 |
 | MS Visual Studio (Community) ≥ 16.4 (2019) (Desktop) (No preview)
 
@@ -77,30 +77,30 @@
 
     1. These files are shipped with MySQL Server, search for them at program files directory, MySQL\MySQL Server 8.0\lib / MySQL\MySQL Server 5.7\lib.
 
-1. [OpenSSL](http://www.slproweb.com/products/Win32OpenSSL.html) Download the 64bit version. Or you can get both if you plan to compile both 32 and 64bit, they can coexist side by side.
+1. [OpenSSL](https://www.slproweb.com/products/Win32OpenSSL.html) Download the 64bit version. Or you can get both if you plan to compile both 32 and 64bit, they can coexist side by side.
 
     1. Find the 64bit version by finding the latest 1.0.x or 1.1.x Win64 OpenSSL that is NOT the "light" version. (Example: Win64 OpenSSL v1.1.1g)
     
     1. Find the 32bit version by finding the latest 1.0.x or 1.1.x Win32 OpenSSL that is NOT the "light" version. (Example: Win32 OpenSSL v1.1.1g)
 
     1. *Note #1: If you get a "Missing Microsoft Visual C++ 2008 Redistributable" error message while installing OpenSSL,*
-       *download the [Microsoft Visual C++ 2008 Redistributable Package (x64)](http://www.microsoft.com/en-us/download/details.aspx?id=29) (1.7MB Installer) and install it.*
-       *If you need 32bit support, download and install the [Microsoft Visual C++ 2008 Redistributable Package (x86)](http://www.microsoft.com/en-us/download/details.aspx?id=15336).*
+       *download the [Microsoft Visual C++ 2008 Redistributable Package (x64)](https://my.visualstudio.com/Downloads?pid=620) (x64) and install it.*
+       *If you need 32bit support, download and install from the same link, but select x86 instead*
        
-    1. *Note #2: While installing OpenSSL, choose The OpenSSL binaries (/bin) directory (NOT "The Windows system directory")*
+    2. *Note #2: While installing OpenSSL, choose The OpenSSL binaries (/bin) directory (NOT "The Windows system directory")*
        *when given the choice on where to copy the OpenSSL DLLs. These DLLs will need to be located easily for [Core Installation](windows-core-installation).*
   
-1. [Boost](https://www.boost.org/).
+2. [Boost](https://www.boost.org/).
 
     1. Download the prebuilt Windows Binary for Visual Studio 2019
 
-    1. `1.70.0` is the minimum version required for Visual Studio 2019, but Version `1.74.0`is recommended
+    2. `1.70.0` is the minimum version required for Visual Studio 2019, but Version `1.74.0`is recommended
 
-    1. 64bit: https://sourceforge.net/projects/boost/files/boost-binaries/1.74.0/boost_1_74_0-msvc-14.2-64.exe/download
+    3. 64bit: https://sourceforge.net/projects/boost/files/boost-binaries/1.74.0/boost_1_74_0-msvc-14.2-64.exe/download
 
-    1. 32bit: https://sourceforge.net/projects/boost/files/boost-binaries/1.74.0/boost_1_74_0-msvc-14.2-32.exe/download
+    4. 32bit: https://sourceforge.net/projects/boost/files/boost-binaries/1.74.0/boost_1_74_0-msvc-14.2-32.exe/download
 
-    1. Add an environment variable to "System" variable named "BOOST_ROOT" and as value your Boost installation directory, e.g `E:/Programs/boost_1_74_0`. Important is to use '**/**', not '**\\**'  when pointing to directory. (Make sure that it does not have a trailing slash (end of path). If you still get problems, add the same variable in the `USER` variables section too, like shown in the image below.)
+    5. Add an environment variable to "System" variable named "BOOST_ROOT" and as value your Boost installation directory, e.g `E:/Programs/boost_1_74_0`. Important is to use '**/**', not '**\\**'  when pointing to directory. (Make sure that it does not have a trailing slash (end of path). If you still get problems, add the same variable in the `USER` variables section too, like shown in the image below.)
 
     <a href="/wiki/images/boost.jpg" target="_blank">
     <img src="/wiki/images/boost.jpg" height="50%" width="50%">

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -84,7 +84,7 @@
     1. Find the 32bit version by finding the latest 1.0.x or 1.1.x Win32 OpenSSL that is NOT the "light" version. (Example: Win32 OpenSSL v1.1.1g)
 
     1. *Note #1: If you get a "Missing Microsoft Visual C++ 2008 Redistributable" error message while installing OpenSSL,*
-       *download the [Microsoft Visual C++ 2008 Redistributable Service Pack 1](http://www.microsoft.com/download/details.aspx?id=26368) (x64) and install it.*
+       *download the [Microsoft Visual C++ 2008 Redistributable Service Pack 1](https://www.microsoft.com/download/details.aspx?id=26368) (x64) and install it.*
        *If you need 32bit support, download and install from the same link, but select x86 instead*
        
     2. *Note #2: While installing OpenSSL, choose The OpenSSL binaries (/bin) directory (NOT "The Windows system directory")*

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -84,7 +84,7 @@
     1. Find the 32bit version by finding the latest 1.0.x or 1.1.x Win32 OpenSSL that is NOT the "light" version. (Example: Win32 OpenSSL v1.1.1g)
 
     1. *Note #1: If you get a "Missing Microsoft Visual C++ 2008 Redistributable" error message while installing OpenSSL,*
-       *download the [Microsoft Visual C++ 2008 Redistributable Package (x64)](https://my.visualstudio.com/Downloads?pid=620) (x64) and install it.*
+       *download the [Microsoft Visual C++ 2008 Redistributable Service Pack 1](http://www.microsoft.com/download/details.aspx?id=26368) (x64) and install it.*
        *If you need 32bit support, download and install from the same link, but select x86 instead*
        
     2. *Note #2: While installing OpenSSL, choose The OpenSSL binaries (/bin) directory (NOT "The Windows system directory")*
@@ -94,7 +94,7 @@
 
     1. Download the prebuilt Windows Binary for Visual Studio 2019
 
-    2. `1.70.0` is the minimum version required for Visual Studio 2019, but Version `1.74.0`is recommended
+    2. `1.70.0` is the minimum version required for Visual Studio 2019, but Version `1.74.0` is recommended
 
     3. 64bit: https://sourceforge.net/projects/boost/files/boost-binaries/1.74.0/boost_1_74_0-msvc-14.2-64.exe/download
 

--- a/sync-wiki.sh
+++ b/sync-wiki.sh
@@ -5,8 +5,8 @@
 #
 
 git pull origin master
-cd wiki
+cd wiki || return
 git pull origin master
-cd ..
+cd .. || return
 git commit -a -m "updated wiki"
 git push origin master


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Fixed a bunch of spelling errors (https://github.com/azerothcore/wiki/issues/565)
- Fixed a few dead links (https://github.com/azerothcore/wiki/issues/562)
- Slightly elaborated on a few CMake and CLI options (https://github.com/azerothcore/wiki/issues/565)
- Made more universal scripting changes (such as getting the current directory the user is in instead of writing it as so to make the process more easier for the end user) (https://github.com/azerothcore/wiki/issues/564)
- Added tiny error handling in sync-wiki.sh to avoid the rare possibility of destroying your local repo if one of the commands fail (https://github.com/azerothcore/wiki/issues/564)
- Have Docker Compose open only TCP ports instead of both UDP and TCP for slight security and not need to attempt to open another protocol (https://github.com/azerothcore/wiki/issues/563)
- Improve some formatting of certain areas of the wiki such as the Linux Installation CMake command and config files (https://github.com/azerothcore/wiki/issues/565)
- Improve consistency of certain instructions such as macOS using `-DTOOLS=1` but not Linux (https://github.com/azerothcore/wiki/issues/564)
- Added missing gem that would cause Jekyll on Ruby 3.0 to fail (see upstream issue here https://github.com/jekyll/jekyll/issues/8523)

## Motivation and Context
Improves the readability and following processes easier for the end user.

## How Has This Been Tested?
I could not get the local wiki setup, even using Docker, at all due to an invalid Markdown processor (GFM is not valid?). Tried setting it to kramdown and kramdown use GFM, but any page I went to on the wiki would result in endless refreshing. I resorted to deploying GitHub Pages on my fork and everything works well there.