### PR TITLE
fix: typo `worlserver` to `worldserver`

### DIFF
--- a/docs/creating-accounts.md
+++ b/docs/creating-accounts.md
@@ -35,7 +35,7 @@ account set password <user> <password> <password>
 
 ## Higher security level
 
-The highest security level is SEC_CONSOLE (4) which your worlserver has by default.
+The highest security level is SEC_CONSOLE (4) which your worldserver has by default.
 
 It has access to account management and is not recommended for in-game accounts for anyone that does not know what they are doing.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixing a typo in the docs

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
