### PR TITLE
Fix minor spelling/phrasing issues with home.md

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -4,7 +4,7 @@ redirect_from: "/"
 
 # Home
 
-Welcome to the [AzerothCore](http://www.azerothcore.org/) project wiki powered by [Drassil/Git-Wiki](https://github.com/Drassil/git-wiki)
+Welcome to the [AzerothCore](http://www.azerothcore.org/) project wiki, powered by [Drassil/Git-Wiki](https://github.com/Drassil/git-wiki)
 
 Read in: [English :gb:](home) [Spanish :es:](es/home)
 
@@ -18,25 +18,25 @@ Read in: [English :gb:](home) [Spanish :es:](es/home)
 
 ## Overview
 
-AzerothCore is a complete Open Source and Modular solution for MMO
+AzerothCore is a complete Open Source and Modular solution for MMO development.
 
 ### Solid base
 
-AzerothCore has a strong and solid base, coming from years of development: it is based on MaNGOS, TrinityCore and SunwellCore.
-We're improving this reliability offering a project that follow specific versioning rules, allowing you to develop in the right way. Read More...
+AzerothCore has a strong and solid base, coming from years of development. It is based on MaNGOS, TrinityCore and SunwellCore.
+We're improving this reliability, offering a project that follows specific versioning rules, allowing you to develop in the right way. Read More...
 
 ### Playable
 Our main goal is to provide a fully working and playable server application. We will focus our stable revisions on final user experiences, instead of following strict development patterns like our predecessors.
-Of course we will work to improve the code in every new versions that are under development stage.
+Of course we will work to improve the code in every new version that is under development.
 
 ### Open Source
-AzerothCore modules are released under GNU AGPL 3.0 and GNU GPL 2.0, both those liceses are totally free and open source. We believe in the free software, we love cooperation.
+AzerothCore modules are released under GNU AGPL 3.0 and GNU GPL 2.0. Both of these licenses are totally free and open source. We believe in the free software, and we love cooperation.
 
-### Tested, realiable, updated
-SunwellCore, the father of AzerothCore, had been running with thousands of players for years. The goal of AzerothCore is to keep this game application updated, continuing its development.
+### Tested, reliable, updated
+SunwellCore, the father of AzerothCore, successfully ran with thousands of players for years. The goal of AzerothCore is to keep this game application updated, continuing its development.
 
 ### Community-driven
-The main strenght of AzerothCore is its community. Users can help us by improving our code base or simply by submitting any bug report. If you want to contribute, we'd love it!
+The main strength of AzerothCore is its community. Users can help us by improving our code base or simply by submitting any bug report. If you want to contribute, we'd love it!
 
 ### Modular
-We try to make our software as modular as possible, because modular software is much easier to be extended.
+We try to make our software as modular as possible, because modular software is much easier to extend.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description
This is just fixing some minor spelling/grammar mistakes and phrasing on the home page to make it clearer. 

The only questionable one was the first line (original was an incomplete sentence saying "AzerothCore is a complete Open Source and Modular solution for MMO") which is a sentence that could be ended a few different ways ('emulation', 'framework', even 'gaming'.) I went with 'development', but see what you think.

### Related Issue

Closes
