### PR TITLE
Improved average wander distance query

### DIFF
--- a/docs/useful-sql.md
+++ b/docs/useful-sql.md
@@ -108,7 +108,7 @@ Handy for fixing static creatures.
 ```sql
 SELECT c.id, AVG(c.wander_distance)
 FROM `creature` c
-WHERE c.id = XXXX;
+WHERE c.id = XXXX AND c.wander_distance > 0;
 ```
 
 ### Find other members of a node pool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description
The average wander distance query was including creatures with 0 distance, thus giving incorrectly low results. This fxes that. Thanks to @syssneck for the suggestion.