### PR TITLE
chore(docs): Emphasize that broadcast_text is sniffed and shouldn't b…

### DIFF
--- a/docs/broadcast_text.md
+++ b/docs/broadcast_text.md
@@ -8,9 +8,10 @@ This table (ref <https://github.com/TrinityCore/TrinityCore/commit/60e87db>) wi
 
 Its purpose is (will be) used as a globalized table containing the texts as mentionned above, and things like their sounds, their emotes and the languages in which the texts should be said.
 
- 
-
 All the values are from sniffs (ADBVerified) so, don't add things in it - Kinzcool.
+
+ **Values from this table come from sniffs (retail data) and should not be changed unless you are absolutelly sure they have been wrongly changed before.**
+ **Most of the time, the values here are correct and your script needs to be fixed. Please ensure your script works correctly before suggesting changes to this table.**
 
 **Structure**
 

--- a/docs/broadcast_text.md
+++ b/docs/broadcast_text.md
@@ -11,6 +11,7 @@ Its purpose is (will be) used as a globalized table containing the texts as ment
 All the values are from sniffs (ADBVerified) so, don't add things in it - Kinzcool.
 
  **Values from this table come from sniffs (retail data) and should not be changed unless you are absolutelly sure they have been wrongly changed before.**
+ 
  **Most of the time, the values here are correct and your script needs to be fixed. Please ensure your script works correctly before suggesting changes to this table.**
 
 **Structure**


### PR DESCRIPTION
…e touched (most of the time anyway)

<!--- Provide a general summary of your changes in the Title above -->
Emphasize that users should ensure their scripts work correctly before opening PRs that suggest changing broadcast_text data, as that table comes entirely from WDB and shouldn't ever be touched.

I was informed that some rows were changed before so I presume there might be cases where it might actually need to be corrected, so I mentioned that "most of the time" it's correct, but perhaps that part could've been worded better.
<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description

### Related Issue

Closes
