### PR TITLE
chore: add config step

### DIFF
--- a/docs/install-with-docker.md
+++ b/docs/install-with-docker.md
@@ -61,6 +61,11 @@ git clone https://github.com/azerothcore/azerothcore-wotlk.git
 
 Now go into the main directory using `cd azerothcore-wotlk`. **All commands will have to be run inside this folder**.
 
+Before we install let's get a copy of our own config.sh from the distribution
+```
+cp conf/dist/config.sh conf/config.sh
+```
+
 ### Installation
 
 Inside your terminal (if you use Windows, use git bash), run the following commands inside the azerothcore-wotlk folder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Due to reoccurring question in docker channel, lets add this step to wiki
Unlike other config files like worlderserver etc. This config path is hardcoded in scripts such that the user may have no idea that it faults the build process. Yes, there is a notice displayed, but people do not realize it should be a fatal error not notice.

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description

### Related Issue

Closes
