### PR TITLE
Update linux-requirements.md

### DIFF
--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -8,7 +8,7 @@
 | |
 | :- |
 | MySQL ≥ 5.7.0 |
-| Boost ≥ 1.67 |
+| Boost ≥ 1.74 |
 | CMake ≥ 3.16 |
 | Clang ≥ [10](https://github.com/azerothcore/azerothcore-wotlk/actions?query=workflow%3Acore-build) |
 


### PR DESCRIPTION
Changed the minimum required version of Boost to 1.74 as per user: "Revision - tkn963" in the Discord.

<!--- Provide a general summary of your changes in the Title above -->

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description

### Related Issue

Closes
