### PR TITLE
Added three necessary programs to the dependency list for ac-dashboard-core-installation.md 

### DIFF
--- a/docs/ac-dashboard-core-installation.md
+++ b/docs/ac-dashboard-core-installation.md
@@ -9,10 +9,11 @@ If you need any help just [ask a question](https://www.azerothcore.org/wiki/How-
 
 ## Requirements
 
-You need to have [git](https://git-scm.com/) installed in your machine. 
+You need to have [git](https://git-scm.com/), [curl](https://curl.se/), [unzip](https://github.com/madler/unzip), [sudo](https://www.sudo.ws/) installed in your machine. 
 No other software is required to be installed manually.
 
-- debian/ubuntu-based: `apt update && apt install git`
+
+- debian/ubuntu-based: `apt update && apt install git curl unzip sudo`
 - macOS: `brew install git`
 
 ### Notes


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description

`curl`, `sudo` (Needed for `acore.sh`), and unzip (needed for deno) does not come with the RPI debian bullseye image. This PR corrects this.


### Related Issue

N/A