### PR TITLE
typo found in linux-requirements.md

### DIFF
--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -9,7 +9,7 @@
 | :- |
 | MySQL ≥ 5.7.0 |
 | Boost ≥ 1.74 |
-| OpenSLL ≥ 1.0.x (OpenSSL 3.0 is not supported) |
+| OpenSSL ≥ 1.0.x (OpenSSL 3.0 is not supported) |
 | CMake ≥ 3.16 |
 | Clang ≥ [10](https://github.com/azerothcore/azerothcore-wotlk/actions?query=workflow%3Acore-build) |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description
Possible typo `OpenSLL` to `OpenSSL`
### Related Issue

Closes
