### PR TITLE
fix: incorrect link in final server steps footer

### DIFF
--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -50,4 +50,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 5: Networking](networking.md) | [Step 7: Client Setup >>](client-setup.md) |
+| [<< Step 5: Networking](networking.md) | [Step 7: Keeping the Server Up-to-Date >>](keeping-the-server-up-to-date.md) |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description

Fixes an incorrect link in the Final Server Steps footer.

### Related Issue

Closes #771 
