### PR TITLE
Remove reference to DB Assembler, clean up spelling/grammar.

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -8,7 +8,7 @@ redirect_from: "/Update"
 
 1. Type `.server debug` in your console.
   
-    1. If it outputs `Using World DB: ACDB 335.4-dev` then you can proceed to [Update your local source](#update-your-local-source).
+    1. If it outputs `Using World DB: ACDB 335.7-dev` then you can proceed to [Update your local source](#update-your-local-source).
   
     1. If it outputs anything else for `Using World DB:` then you first need to follow [this guide on updating to latest master](upgrade-from-pre-3.0.0-to-latest-master.md).
 
@@ -24,9 +24,9 @@ Move to your AzerothCore sources directory.
 
 ## Recompile
 
-Compile again your sources, this step is the same as the [Compilation step during Installation](Installation#3-compiling), but generally you can skip the CMake part unless you're adding new modules.
+Compile your source again, this step is the same as the [compilation step during installation](Installation#3-compiling), but generally you can skip the CMake part unless you're adding new modules.
 
-For example, in Linux/Mac you just have to `cd build;` and run `make -j 8; make install`. Of course you can change the value of the `-j` paramether according to your CPU.
+For example, in Linux/Mac you just have to `cd build;` and run `make -j 8; make install`. Of course you can change the value of the `-j` parameter according to your CPU.
 
 ## Update the Database
 
@@ -34,8 +34,4 @@ For example, in Linux/Mac you just have to `cd build;` and run `make -j 8; make 
 
 You need to import the **new** sql update files (located at https://github.com/azerothcore/azerothcore-wotlk/tree/master/data/sql/updates) to each database.
 
-To automate this process you can use the db-assembler bash script `bash apps/db_assembler/db_assembler.sh`.
-
-If this is the first time you are using it [READ THIS FIRST](database-installation.md) and properly configure your `conf/config.sh` file.
-
-![](https://user-images.githubusercontent.com/75517/50738699-6912ee80-11d7-11e9-95ea-667baa0bda70.png)
+To automate this process, both the authserver and worldserver have database updaters inside of them as described [here](https://www.azerothcore.org/wiki/database-installation). This means that once you recompile your source, all you'd need to do is launch the authserver and worldserver as you would normally.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- 
     Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
     https://www.azerothcore.org/wiki/wiki-standards 
-->

### Description

Removes section on updating with the deprecated DB assembler and replaces it with using the auth/worldserver's built-in updaters.
Updates version of DB you need to check for, will need to update the `upgrade-from-pre-3.0.0-to-latest-master` page to detail the more recent DB squashes as well as their respective commits to checkout.
Cleans up a couple grammar/spelling mistakes.

### Related Issue

Closes unreported issue.
