### PR TITLE
Update networking.md

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -34,7 +34,7 @@ You need to make sure that your **authserver** application directs incoming conn
  - MySQL CLI Commands (This step is not needed if you used a MySQL Manager like HeidiSQL)
     - `$ sudo mysql`
     - You should see a prompt change to mysql>
-    - use acore_world;
+    - `use acore_auth`;
     - **Replace your IP with the one you've chosen to use from above**
     - `UPDATE realmlist SET address = '[your_ip]' WHERE id = 1;`
     - exit


### PR DESCRIPTION
Updates networking.md instructions for setting realmlist IP.

### Description
- Currently, the instructions incorrectly reference `acore_world` as the database containing the `realmlist` table. From what I see, `acore_auth` is the database that contains the `realmlist` table.

- This updates networking.md to correctly `use acore_auth;` instead.

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home