### PR TITLE
Changed cmake TOOLS parameter to actual TOOLS_BUILD

### DIFF
--- a/docs/es/linux-core-installation.md
+++ b/docs/es/linux-core-installation.md
@@ -65,7 +65,7 @@ echo $HOME
 **Note**: in case you use a non-default package for `clang`, you need to replace it accordingly. For example, if you installed `clang-6.0` then you have to replace `clang` with `clang-6.0` and `clang++` with `clang++-6.0`
 
 ```sh
-cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_WARNINGS=1 -DTOOLS=0 -DSCRIPTS=static
+cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_WARNINGS=1 -DTOOLS_BUILD=all -DSCRIPTS=static
 ```
 
 To know the amount of cores available.

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -65,7 +65,7 @@ echo $HOME
 **Note**: in case you use a non-default package for `clang`, you need to replace it accordingly. For example, if you installed `clang-6.0` then you have to replace `clang` with `clang-6.0` and `clang++` with `clang++-6.0`
 
 ```sh
-cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_WARNINGS=1 -DTOOLS=0 -DSCRIPTS=static -DMODULES=static
+cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/ -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_WARNINGS=1 -DTOOLS_BUILD=all -DSCRIPTS=static -DMODULES=static
 ```
 
 To know the amount of cores available.

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -62,7 +62,7 @@ At this point, you must be in your "build/" directory.
 export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
 cmake ../ \
 -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/  \
--DTOOLS=0 \
+-DTOOLS_BUILD=all \
 -DSCRIPTS=static \
 -DMYSQL_ADD_INCLUDE_PATH=/usr/local/include \
 -DMYSQL_LIBRARY=/usr/local/lib/libmysqlclient.dylib \


### PR DESCRIPTION
### Description
* Current section "Linux Core Installation" [mentions](https://www.azerothcore.org/wiki/linux-core-installation) the old `TOOLS` parameter. Currently, this parameter has been replaced with `TOOLS_BUILD`. It is also worth specifying the value of this parameter as "all", since map tools will be required in the following steps of the instruction.

### Related Issue


## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
