### PR TITLE
Change OpenSSL section of the Windows install guide to suggest 3.0 instead of 1.0/1.1

### DIFF
--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -157,7 +157,7 @@ For 64-bit version:
 
 #### OpenSSL 3.0 and more recent installed, you need to copy:
 
-**legacy.dll**
+**legacy.dll**  → C:\OpenSSL-Win(32/64)\bin
 
 #### About compilation log and report
 

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -81,9 +81,9 @@
 
 1. [OpenSSL](http://www.slproweb.com/products/Win32OpenSSL.html) Download the 64bit version. Or you can get both if you plan to compile both 32 and 64bit, they can coexist side by side.
 
-    - Find the 64bit version by finding the latest 1.0.x or 1.1.x Win64 OpenSSL that is NOT the "light" version. (Example: Win64 OpenSSL v1.1.1g)
+    - Find the 64bit version by finding the latest 3.0.x Win64 OpenSSL that is NOT the "light" version. (Example: Win64 OpenSSL v3.0.7)
     
-    - Find the 32bit version by finding the latest 1.0.x or 1.1.x Win32 OpenSSL that is NOT the "light" version. (Example: Win32 OpenSSL v1.1.1g)
+    - Find the 32bit version by finding the latest 3.0.x Win32 OpenSSL that is NOT the "light" version. (Example: Win32 OpenSSL v3.0.7)
 
     - *Note #1: If you get a "Missing Microsoft Visual C++ .... Redistributable" error message while installing OpenSSL,*
       *Download the [Microsoft Visual C++ 2017/2019/2022 Redistributable Package (x64) (Direct Download)](https://aka.ms/vs/17/release/vc_redist.x64.exe) (1.7MB Installer) and install it.*


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description
- Updates the Windows requirements page to recommend OpenSSL 3.0 instead of 1.0/1.1.
- Also adds a path to find `legacy.dll` in the Windows core installation page like the other `*.dll* files.

### Related Issue
Closes unreported issue.

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
