### PR TITLE
(EN) Added required file for OpenSSL 3.0

### DIFF
--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -125,6 +125,7 @@ libmysql.dll
 libeay32.dll / libcrypto-1_1.dll / libcrypto-1_1-x64.dll (Only for OpenSSL 1.1.x and below)
 ssleay32.dll / libssl-1_1.dll / libssl-1_1-x64.dll (Only for OpenSSL 1.1.x and below)
 legacy.dll (Only for OpenSSL 3.0 and later)
+libcrypto-3-x64.dll (Only for OpenSSL 3.0 and later)
 ```
 
 In the **configs** folder you should find:


### PR DESCRIPTION
Added required file entry: libcrypto-3-x64.dll (Only for OpenSSL 3.0 and later)

### Description

- With OpenSSL 3.0, we need to also copy over the **libcrypto-3-x64.dll** file, not **just legacy.dll**
- The Spanish page differs from the English one, with it saying that OpenSLL 3.0 is not supported. I only know a few words of Spanish, so I can't rewrite it.
