### PR TITLE
Create SQL standard for capitalization of SQL tables/columns.

### DIFF
--- a/docs/sql-standards.md
+++ b/docs/sql-standards.md
@@ -142,6 +142,24 @@ UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`&~(6
 
 ## Tables and Columns
 
+### Naming of tables and columns
+
+For the most part, tables should be written in snake case, and columns should be written in upper camel case.
+
+Tables:
+```
+broadcast_text
+creature_loot_template
+points_of_interest
+```
+
+Columns:
+```
+MaleText
+QuestRequired
+PositionX
+```
+
 ### Integers
 
 We do not define the width of an integer when we create new columns. (Width is deprecated in later versions of MySQL 8)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description
- Create a standard on the capitalization of SQL tables and columns based on some feedback from the Discord server:
Tables: snake case (creature_loot_template) lowercase, underscores between words.
Columns: upper camel case (RaceMask) uppercase first letter, no space between words.

If approved, I can go through and change tables/columns to actually match this standard (or whatever standard we choose), since there is currently a lot of inconsistency regarding this subject.

### Related Issue
Closes unreported issue.

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
