### PR TITLE
Update SQL naming standard to accommodate acronyms.

### DIFF
--- a/docs/sql-standards.md
+++ b/docs/sql-standards.md
@@ -162,6 +162,7 @@ UPDATE `creature_template` SET `mechanic_immune_mask`=`mechanic_immune_mask`&~(6
 For the most part, tables should be written in snake case, and columns should be written in upper camel case.
 
 Tables:
+
 ```
 broadcast_text
 creature_loot_template
@@ -169,10 +170,29 @@ points_of_interest
 ```
 
 Columns:
+
 ```
 MaleText
 QuestRequired
 PositionX
+```
+
+In the case of column names with acronyms (e.g. GUID, ID, NPC, etc) the letters in the acronym should be uppercase.
+
+Wrong:
+
+```
+Itemguid
+DisplayId
+RequiredNpcOrGoCount
+```
+
+Correct:
+
+```
+ItemGUID
+DisplayID
+RequiredNPCOrGOCount
 ```
 
 ### Integers


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description
- Creates a defined way to handle acronyms in SQL column names.

### Related Issue
Closes unreported issue.

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
