### PR TITLE
updated not documented flag: CREATURE_FLAG_EXTRA_HARD_RESET

### DIFF
--- a/docs/creature_template.md
+++ b/docs/creature_template.md
@@ -705,7 +705,8 @@ These flags control certain creature specific attributes. Flags can be added tog
 | 268435456  | CREATURE_FLAG_EXTRA_DUNGEON_BOSS                    | 0x10000000 | Creature is a dungeon boss. This flag is generically set by core during runtime. Setting this in database will give you startup error.             |
 | 536870912  | CREATURE_FLAG_EXTRA_IGNORE_PATHFINDING              | 0x20000000 | Creature will ignore pathfinding. This is like disabling Mmaps, only for one creature.                                                             |
 | 1073741824 | CREATURE_FLAG_EXTRA_IMMUNITY_KNOCKBACK              | 0x40000000 | creature will immune all knockback effects                                                                                                         |
-| 2147483648 | CREATURE_FLAG_EXTRA_HARD_RESET | 0x80000000 | Creature will despawn on evade                                                                                                         |
+| 2147483648 | CREATURE_FLAG_EXTRA_HARD_RESET                      | 0x80000000 | Creature will despawn on evade                                                                                                         |
+
 #### ScriptName
 
 The name of the script that this creature uses, if any. This ties a script from a scripting engine to this creature.

--- a/docs/creature_template.md
+++ b/docs/creature_template.md
@@ -705,7 +705,7 @@ These flags control certain creature specific attributes. Flags can be added tog
 | 268435456  | CREATURE_FLAG_EXTRA_DUNGEON_BOSS                    | 0x10000000 | Creature is a dungeon boss. This flag is generically set by core during runtime. Setting this in database will give you startup error.             |
 | 536870912  | CREATURE_FLAG_EXTRA_IGNORE_PATHFINDING              | 0x20000000 | Creature will ignore pathfinding. This is like disabling Mmaps, only for one creature.                                                             |
 | 1073741824 | CREATURE_FLAG_EXTRA_IMMUNITY_KNOCKBACK              | 0x40000000 | creature will immune all knockback effects                                                                                                         |
-
+| 2147483648 | CREATURE_FLAG_EXTRA_HARD_RESET | 0x80000000 | Creature will despawn on evade                                                                                                         |
 #### ScriptName
 
 The name of the script that this creature uses, if any. This ties a script from a scripting engine to this creature.


### PR DESCRIPTION
Adding documentation for the flag CREATURE_FLAG_EXTRA_HARD_RESET added in [CreatureData.h](https://github.com/azerothcore/azerothcore-wotlk/commit/d464ee7083f6321aa4d33c3f68c2432b247c38e0#diff-ff0e6d9ad5d397cd8b04eee23afc146d89fd5d55940d02e321365bb9de883841)