### PR TITLE
remove OpenSSL 3.x warnings

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -10,10 +10,6 @@ Read in: [English :gb:](home) [Spanish :es:](es/home)
 
 ## IMPORTANT NOTE
 
-**OpenSSL 3.x is NOT SUPPORTED. Use the version the installation guide points to.**
-
-**Ubuntu 22.0 and later ships with OpenSSL 3.x! If you want to use Ubuntu, use a lower version or compile a lower version of OpenSSL**
-
 **The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice.**
 
 ## Getting started


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

- Remove home warning about OpenSSL 3.x because it's now supported
- 

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
