### PR TITLE
ac-dashboard-core-install: Fix conf file section

### DIFF
--- a/docs/ac-dashboard-core-installation.md
+++ b/docs/ac-dashboard-core-installation.md
@@ -79,9 +79,9 @@ Get the latest client data:
 ./acore.sh client-data
 ```
 
-### Server config files (optional)
+### Server config files
 
-create these 2 files if you want to change the default configurations of the server 
+create these 2 files. They contain the default configuration for the worldserver and authserver, if you don't wish to modify simply copying them is enough.
 
 #### Linux and Mac
 


### PR DESCRIPTION
The current worldserver and authserver fails to load if you don't have the worldserver.conf and authserver.conf. The ./acore run-{world,auth}server commands also gets stuck in an infinite loop and bails (nice check!) due to worldserver and authserver returning a non-zero exit value.

This was required to make this work under Ubuntu on WSL2 running on Windows 11.

<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

- 
- 

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
