### PR TITLE
Add information about client downloads to wiki

### DIFF
--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -5,7 +5,7 @@
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
 | [<< Step 7: Keeping the Server Up-to-Date](keeping-the-server-up-to-date.md) | [Step 9: Installing a Module >>](installing-a-module.md) |
 
-- Make sure you use an original WotLK client, and *not* WOW Classic. You can find downloads at [ChromieCraft](https://www.chromiecraft.com/en/downloads/)
+- Make sure you use an original WotLK client, and *not* WOW Classic. You can find downloads at [ChromieCraft](https://www.chromiecraft.com/en/downloads/) or [WOWgaming](https://wowgaming.github.io/wiki-en/wotlk-home.html#client)
 
 - Open the realmlist.wtf file inside your **WoW\Data** folder. The IP in the realmlist.wtf file should be exactly the same as the IP address you entered in the realmlist table previously.
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -5,6 +5,8 @@
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
 | [<< Step 7: Keeping the Server Up-to-Date](keeping-the-server-up-to-date.md) | [Step 9: Installing a Module >>](installing-a-module.md) |
 
+- Make sure you use an original WotLK client, and *not* WOW Classic. You can find downloads at [ChromieCraft](https://www.chromiecraft.com/en/downloads/)
+
 - Open the realmlist.wtf file inside your **WoW\Data** folder. The IP in the realmlist.wtf file should be exactly the same as the IP address you entered in the realmlist table previously.
 
     - Change the first line to: set realmlist <IP address used in realmlist table>


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

- Added a download link to chromiecraft for an old client
- Added a warning about not using WOW Classic clients.

### Related Issue

n/a

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
