### PR TITLE
Update documentation to use INSTALL step under Windows builds

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -27,7 +27,7 @@ Github link:
 
 1. Download the files above.
 
-1. Create a new folder within the build folder called **Data**. i.e **C:\Build\AzerothCore\RelWithDebInfo\Data**
+1. Create a new folder within the server folder you created in the previous step, in this case **C:\Server**, called **Data**. i.e **C:\Server\Data**
 
 1. Extract the files from the zip file and place them within the **Data** folder.
 
@@ -51,7 +51,7 @@ By default you will compile your core with tools and you will get the following 
 
 Place the files with your World of Warcraft binary (wow.exe on windows) and run them.
 
-After extracting all necessary files, create a folder called **Data** within the **RelWithDebInfo** or **Debug** directory and place the files in there. Alternatively you can specify a different directory where you want to keep them by changing DataDir value in the worldserver.conf file.
+After extracting all necessary files, create a folder called **Data** within the server directory you created earlier, in this case **C:\Server**, and place the files in there. Alternatively you can specify a different directory where you want to keep them by changing DataDir value in the worldserver.conf file.
 
 If you use extractors from other projects or branches it is almost certain that your AzerothCore will not recognize the extracted data or even work!
 
@@ -78,11 +78,7 @@ You need to run Mapextractor.exe before the makevmaps_simple.bat.
 
 ### Creating the config files
 
-1. Make copies of both .dist files.
-
-1. From each copy, remove the .dist part.
-
-Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
+Open the .conf files in **C:\Server\configs** and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
 
 On a newly compiled configuration, you will have the following values by default
 
@@ -114,7 +110,7 @@ The following steps must be verified:
 
 1. In your worldserver.conf file locate **DataDir** option.
 
-1. Edit it to the path of your folder. i.e **C:\Build\AzerothCore\RelWithDebInfo\Data**
+1. Edit it to the path of your folder. This can be either a static or a relative path. Ie. **C:\Server\Data** or **.\Data**.
 
 *Pro Tip: For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server.*
 

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -15,6 +15,8 @@ See [Requirements](requirements.md) before you continue.
 
 1. Create the directory where the source files will be located. In this guide we will use **C:\Azerothcore**.
 
+1. Create the directory where the server should be installed to. In this guide we will use **C:\Server**.
+
 1. Open up Github Desktop
 
 1. Click **File** -> **Clone repository...** in the top left
@@ -47,6 +49,8 @@ Before you begin, create a new directory called **Build**. In this guide we will
 1. Make sure that **Use default native compilers** is checked.
 
 1. Click **Finish**.
+
+1. In the **CMAKE_INSTALL_PREFIX** value field, enter your server folder as created earlier. In this case, `C:\Server`.
 
 1. Make sure **TOOLS_BUILD** is set to `all`. This will compile the extractors needed later in the setup.
 
@@ -122,9 +126,23 @@ When the build is complete you will find a message in the output that looks simi
 ========== Build: 22 succeeded, 0 failed, 0 up-to-date, 1 skipped ==========
 ```
 
-You will find your freshly compiled binaries in the **C:\Build\bin\RelWithDebInfo** or **C:\Build\bin\Debug** folder. These are all used to run your server at the end of this instruction.
+Now that the source is compiled, right-click **INSTALL** and select **Build**. This will move all the compiled binaries and configuration files to **C:\Server** as defined earlier.
 
-You will need the following files in order for the core to function properly:
+When installation is complete, you should see the following message:
+
+```
+2>------ Build started: Project: INSTALL, Configuration: Release x64 ------
+2>-- Install configuration: "Release"
+2>-- Installing: C:/Server/configs/authserver.conf.dist
+2>-- Installing: C:/Server/configs/authserver.conf
+2>-- Installing: C:/Server/authserver.exe
+2>-- Installing: C:/Server/configs/worldserver.conf.dist
+2>-- Installing: C:/Server/configs/worldserver.conf
+2>-- Installing: C:/Server/worldserver.exe
+========== Build: 2 succeeded, 0 failed, 18 up-to-date, 0 skipped ==========
+```
+
+The files in **C:\Server** are all used to run your server at the end of this instruction. You will need the following files in this directory in order for the core to function properly:
 
 ```
 \configs\
@@ -151,7 +169,9 @@ In the **configs** folder you should find:
 
 ```
 authserver.conf.dist
+authserver.conf
 worldserver.conf.dist
+worldserver.conf
 ```
 
 There are two/three DLL files that need to be manually added to this folder, and you need to copy them from the following installation/bin directories:


### PR DESCRIPTION
### Description

Updated documentation to provide clearer and easier installation instructions, using the built-in INSTALL project provided by cmake.

Using the install step is best practice, and you should never really run your production server out of your build folder. The build folder should *always* be considered volatile.

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
