### PR TITLE
Add version of CMake for Intel Mac

### DIFF
--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -50,6 +50,8 @@ cd build
 
 ### Configuring for compiling
 
+The directories Homebrew uses to install packages differs between Macs that have Apple Silicon CPUs and those that have Intel CPUs. Make sure to run the correct CMake command for your machine. You can view your CPU type in `About This Mac`. The commands below are labeled for the relevant CPU type.
+
 Before running the CMake command, replace `$HOME/azeroth-server/` with the path of the server installation (where you want to place the compiled binaries).
 
 Parameter explanation for advanced users [CMake options](cmake-options.md).
@@ -58,6 +60,7 @@ At this point, you must be in your "build/" directory.
 
 **Note**: in the follows command the variable `$HOME` is the path of the **current user**, so if you are logged as root, $HOME will be "/root".
 
+For APPLE SILICON CPUs:
 ```sh
 export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
 cmake ../ \
@@ -68,6 +71,22 @@ cmake ../ \
 -DMYSQL_LIBRARY=/opt/homebrew/lib/libmysqlclient.dylib \
 -DREADLINE_INCLUDE_DIR=/opt/homebrew/opt/readline/include \
 -DREADLINE_LIBRARY=/opt/homebrew/opt/readline/lib/libreadline.dylib \
+-DOPENSSL_INCLUDE_DIR="$OPENSSL_ROOT_DIR/include" \
+-DOPENSSL_SSL_LIBRARIES="$OPENSSL_ROOT_DIR/lib/libssl.dylib" \
+-DOPENSSL_CRYPTO_LIBRARIES="$OPENSSL_ROOT_DIR/lib/libcrypto.dylib"
+```
+
+For INTEL CPUs:
+```sh
+export OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
+cmake ../ \
+-DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/  \
+-DTOOLS_BUILD=all \
+-DSCRIPTS=static \
+-DMYSQL_ADD_INCLUDE_PATH=/usr/local/include/mysql \
+-DMYSQL_LIBRARY=/usr/local/opt/mysql/lib/libmysqlclient.dylib \
+-DREADLINE_INCLUDE_DIR=/usr/local/opt/readline/include \
+-DREADLINE_LIBRARY=/usr/local/opt/readline/lib/libreadline.dylib \
 -DOPENSSL_INCLUDE_DIR="$OPENSSL_ROOT_DIR/include" \
 -DOPENSSL_SSL_LIBRARIES="$OPENSSL_ROOT_DIR/lib/libssl.dylib" \
 -DOPENSSL_CRYPTO_LIBRARIES="$OPENSSL_ROOT_DIR/lib/libcrypto.dylib"

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -62,7 +62,7 @@ At this point, you must be in your "build/" directory.
 
 For APPLE SILICON CPUs:
 ```sh
-export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
+export OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
 cmake ../ \
 -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server/  \
 -DTOOLS_BUILD=all \


### PR DESCRIPTION
### Description

- Homebrew installs packages in different directories depending on if you have an Intel CPU or an Apple Silicon CPU. This is described in the first real paragraph of the [installation docs](https://docs.brew.sh/Installation):

    > The script installs Homebrew to its default, supported, best prefix (/opt/homebrew for Apple Silicon, /usr/local for macOS Intel.

- To account for this, I added a version of the CMake command that uses the `/usr/local` pathing for Intel CPUs.
- For consistency, I also changed the ssl version in the CMake command to `openssl@3` from `openssl@1.1` to be consistent with [the MacOS requirements](https://www.azerothcore.org/wiki/macos-requirements) that ask for `OpenSSL ≥ 3.0` and have you `brew install openssl@3`.

### Related Issue

No related issues, but closed my own before I ever opened it 👍 .


### Further Actions

- I'd be happy to tackle the rewriting of the whole section to clean it up if that is desired, I tried to be minimally invasive with this first pass.
- This page doesn't exist at all for the Spanish version, so unsure what to do there