### PR TITLE
Classic Instalation Wiki - Respective NavBar Path relative to the option chosen.

### DIFF
--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -3,11 +3,11 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](linux-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
 
 ## Required software
 
-See [Requirements](requirements.md) before you continue.
+See [Requirements](linux-requirements.md) before you continue.
 
 ## Getting the source code
 
@@ -150,4 +150,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](linux-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |

--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
 
 | |
 | :- |
@@ -149,4 +149,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |

--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
 
 | |
 | :- |
@@ -149,4 +149,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -3,11 +3,11 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](macos-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
 
 ## Required software
 
-See [Requirements](requirements.md) before you continue.
+See [Requirements](macos-requirements.md) before you continue.
 
 ## Getting the source code
 
@@ -115,4 +115,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](macos-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |

--- a/docs/macos-requirements.md
+++ b/docs/macos-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
 
 | |
 | :- |
@@ -67,4 +67,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |

--- a/docs/macos-requirements.md
+++ b/docs/macos-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
 
 | |
 | :- |
@@ -67,4 +67,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -7,7 +7,7 @@
 
 ## Required software
 
-See [Requirements](windows-core-installation.md) before you continue.
+See [Requirements](windows-requirements.md) before you continue.
 
 ## Pulling & Compiling the source
 

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -3,11 +3,11 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](windows-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
 
 ## Required software
 
-See [Requirements](requirements.md) before you continue.
+See [Requirements](windows-core-installation.md) before you continue.
 
 ## Pulling & Compiling the source
 
@@ -159,4 +159,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](windows-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
 
 {% include callout.html content="Windows ≥ 10<br/>
 Boost ≥ 1.78<br/>
@@ -129,4 +129,4 @@ If you are still having problems, check:
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
 
 {% include callout.html content="Windows ≥ 10<br/>
 Boost ≥ 1.78<br/>
@@ -129,4 +129,4 @@ If you are still having problems, check:
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |


### PR DESCRIPTION


### Description

While following the "Classic Instalation" either of the OS you choose, will correctly continue the next page.
Windows Requirements will take you to Windows Core, instead of making you choose once again, what OS you're doing the setup for it. 

Linux / MacOS / Windows "Requirements" Files have their navbars (going foward) correctly pathed to their respective OS
linux-core-installation | macos-core-installation and windows-core-installation.

Within the the "Installation" files have their navbars (going back) correctly pathed to their respecive OS
linux-requirements | macos-requirements and windows-requirements.

Still in Installation, I've changed the "Required software: See Requirements before you continue." to their respective OS requirements.

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
