### PR TITLE
Adjusted Installation Page and Added How To DBC Data onto Database on the DBC Indexes Pages

### DIFF
--- a/docs/achievement.md
+++ b/docs/achievement.md
@@ -9,10 +9,10 @@ redirect_from: "/Achievement"
 **Achievement.dbc**
 
 This DBC contains all achievements.
-
-[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)      
-
+    
  **Version is : 3.3.5a**
+
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/achievement.md
+++ b/docs/achievement.md
@@ -10,6 +10,8 @@ redirect_from: "/Achievement"
 
 This DBC contains all achievements.
 
+| [How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)      
+
  **Version is : 3.3.5a**
 
 ## Structure

--- a/docs/achievement.md
+++ b/docs/achievement.md
@@ -10,7 +10,7 @@ redirect_from: "/Achievement"
 
 This DBC contains all achievements.
 
-| [How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)      
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)      
 
  **Version is : 3.3.5a**
 

--- a/docs/achievement_criteria.md
+++ b/docs/achievement_criteria.md
@@ -12,6 +12,8 @@ This DBC has been added with WoW 3.0.1.8303 and contains the needed criteria to
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field             | Type    | Notes                                                                |

--- a/docs/areatable.md
+++ b/docs/areatable.md
@@ -12,6 +12,8 @@ This DBC contains the zone and subzone lists. For the purposes of this wiki arti
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Name             | Type   | Notes                                                         |

--- a/docs/areatrigger.md
+++ b/docs/areatrigger.md
@@ -6,6 +6,8 @@
 
 This table contains trigger points for events in certain coordinates in the maps.
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)
+
 **Structure**
 
 | Field       | Type  | Attributes | Key | Null | Default | Extra          | Comment                                              |

--- a/docs/chrclasses.md
+++ b/docs/chrclasses.md
@@ -6,6 +6,8 @@ This DBC contains all possible player classes.
 
 **Version is 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ### Structure
 
 | Column | Name                                         | Type    | Notes                                                                                        |

--- a/docs/chrraces.md
+++ b/docs/chrraces.md
@@ -6,6 +6,8 @@ This DBC contains all possible races, some of which are unused and unavailable t
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ### Structure
 
 | Column | Field                   | Type         | Notes                                                                                |

--- a/docs/dbc-areatrigger.md
+++ b/docs/dbc-areatrigger.md
@@ -12,6 +12,8 @@ This DBC contains information about the triggers of the in-game areas.
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 

--- a/docs/emotes.md
+++ b/docs/emotes.md
@@ -8,6 +8,7 @@ redirect_from: "/Emotes"
 
 This DBC contains emotes which can be used by NPCs.
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/faction.md
+++ b/docs/faction.md
@@ -12,6 +12,7 @@ This DBC contains information on all of the base factions. These factions are un
 
 **IMPORTANT:** These values are used for **ALL** tables **EXCEPT** the [creature\_template](creature_template) and [gameobject\_template\_addon](gameobject_template_addon) tables.
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/factiontemplate.md
+++ b/docs/factiontemplate.md
@@ -12,6 +12,8 @@ This DBC contains information on all of the individual factions. A faction entry
 
 **IMPORTANT: These values are only used for the [creature\_template](creature_template) and [gameobject\_template](gameobject\_template) tables.**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## **Structure**
 
 | Field Nb | Name                                     | Type             |

--- a/docs/holidays.md
+++ b/docs/holidays.md
@@ -8,6 +8,8 @@ redirect_from: "/Holidays"
 
 [`Back-to:DBC`](dbc-index.md)
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field                         | Type    | Notes                                                                              | Extra info                                                                 |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,11 +12,11 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially supported and complete ways of installing AzerothCore, for any purpose (Windows, Linux, macOS).
 
-- [Azerothcore Classic Installation](classic-installation.md) <span class="badge badge-success">Recommended</span> - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
+- [AzerothCore Classic Installation](classic-installation.md) <span class="badge badge-success">Recommended</span> - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
 
-- [AzerothCore Bash Dashboard setup <span class="badge badge-secondary">Limited Support</span>](ac-dashboard-core-installation.md) - the simplest way of installing AzerothCore, recommended for both local development and production.
+- [AzerothCore Bash Dashboard setup](ac-dashboard-core-installation.md) <span class="badge badge-secondary">Limited Support</span> - the simplest way of installing AzerothCore, recommended for both local development and production.
 
-- [Docker setup <span class="badge badge-secondary">Limited Support</span>](install-with-docker.md) - an installation process based on Docker. Docker knowledge is recommended.
+- [Docker setup](install-with-docker.md) <span class="badge badge-secondary">Limited Support</span> - an installation process based on Docker. Docker knowledge is recommended.
 
 ### Install from pre-compiled images <span class="badge badge-info">Limited support and usage</span>
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially supported and complete ways of installing AzerothCore, for any purpose (Windows, Linux, macOS).
 
-- [Azerothcore Classic Installation] <span class="badge badge-success">Recommended</span>(classic-installation.md) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
+- [Azerothcore Classic Installation] [<span class="badge badge-success">Recommended</span>](classic-installation.md) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
 
 - [AzerothCore Bash Dashboard setup <span class="badge badge-secondary">Limited Support</span>](ac-dashboard-core-installation.md) - the simplest way of installing AzerothCore, recommended for both local development and production.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially supported and complete ways of installing AzerothCore, for any purpose (Windows, Linux, macOS).
 
-- [Azerothcore Classic Installation] [<span class="badge badge-success">Recommended</span>](classic-installation.md) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
+- [Azerothcore Classic Installation] (classic-installation.md) [<span class="badge badge-success">Recommended</span>] - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
 
 - [AzerothCore Bash Dashboard setup <span class="badge badge-secondary">Limited Support</span>](ac-dashboard-core-installation.md) - the simplest way of installing AzerothCore, recommended for both local development and production.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially supported and complete ways of installing AzerothCore, for any purpose (Windows, Linux, macOS).
 
-- [Azerothcore Classic Installation] (classic-installation.md) [<span class="badge badge-success">Recommended</span>] - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
+- [Azerothcore Classic Installation](classic-installation.md) <span class="badge badge-success">Recommended</span> - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
 
 - [AzerothCore Bash Dashboard setup <span class="badge badge-secondary">Limited Support</span>](ac-dashboard-core-installation.md) - the simplest way of installing AzerothCore, recommended for both local development and production.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially supported and complete ways of installing AzerothCore, for any purpose (Windows, Linux, macOS).
 
-- [Azerothcore Classic Installation <span class="badge badge-success">Recommended</span>](classic-installation.md) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
+- [Azerothcore Classic Installation] <span class="badge badge-success">Recommended</span>(classic-installation.md) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
 
 - [AzerothCore Bash Dashboard setup <span class="badge badge-secondary">Limited Support</span>](ac-dashboard-core-installation.md) - the simplest way of installing AzerothCore, recommended for both local development and production.
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -6,6 +6,8 @@ redirect_from: "/Languages"
 
 [`Back-to:DBC`](dbc-index.md)
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 **DBC Structure - For Version 3.3.5a**
 
 This DBC contains languages that can be used in texts. The player must have competence in this language to understand what is written.

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -3,11 +3,11 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](linux-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
 
 ## Required software
 
-See [Requirements](requirements.md) before you continue.
+See [Requirements](linux-requirements.md) before you continue.
 
 ## Getting the source code
 
@@ -150,4 +150,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](linux-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |

--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
 
 | |
 | :- |
@@ -149,4 +149,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |

--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |
 
 | |
 | :- |
@@ -149,4 +149,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](linux-core-installation.md) |

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -3,11 +3,11 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](macos-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
 
 ## Required software
 
-See [Requirements](requirements.md) before you continue.
+See [Requirements](macos-requirements.md) before you continue.
 
 ## Getting the source code
 
@@ -115,4 +115,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](macos-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |

--- a/docs/macos-requirements.md
+++ b/docs/macos-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
 
 | |
 | :- |
@@ -67,4 +67,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |

--- a/docs/macos-requirements.md
+++ b/docs/macos-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
 
 | |
 | :- |
@@ -67,4 +67,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Start: Installation Guide](installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md) | [Step 2: Core Installation >>](macos-core-installation.md) |

--- a/docs/map.md
+++ b/docs/map.md
@@ -12,6 +12,8 @@ This DBC contains the maps list.
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field                                                                                                                                                        | Type    | Notes                                                                                                     |

--- a/docs/pagetextmaterial.md
+++ b/docs/pagetextmaterial.md
@@ -12,6 +12,8 @@ This DBC contains material used to display a gossip window for quest or page tex
 
 **Version is : 3.1.3**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field   | Type    |

--- a/docs/skillline.md
+++ b/docs/skillline.md
@@ -12,6 +12,8 @@ This DBC contains all skills.
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field                    | Type         | Notes              |

--- a/docs/spell.md
+++ b/docs/spell.md
@@ -13,6 +13,8 @@ These values are used by the core and a few spell\_\* tables.
 
 **Version 3.3.5**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## **Structure**
 
 | ID  | Name                          | Type   |

--- a/docs/summonproperties_dbc.md
+++ b/docs/summonproperties_dbc.md
@@ -10,6 +10,8 @@ This DBC contains Summon Properties (EffectMiscValueB) for Spell Effect SPELL_EF
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 **Structure**
 
 | Field                | Type | Attributes | Key | Null | Default | Extra | Comment                                                                          |

--- a/docs/totemcategory.md
+++ b/docs/totemcategory.md
@@ -7,7 +7,10 @@ redirect_from: "/TotemCategory"
 [`Back-to:DBC`](dbc-index.md)
 
 **TotemCategory.dbc**
+
 **Version is : 3.3.5a**
+
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -7,7 +7,7 @@
 
 ## Required software
 
-See [Requirements](windows-core-installation.md) before you continue.
+See [Requirements](windows-requirements.md) before you continue.
 
 ## Pulling & Compiling the source
 

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -3,11 +3,11 @@
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](windows-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
 
 ## Required software
 
-See [Requirements](requirements.md) before you continue.
+See [Requirements](windows-core-installation.md) before you continue.
 
 ## Pulling & Compiling the source
 
@@ -159,4 +159,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](requirements.md) | [Step 3: Server Setup >>](server-setup.md) |
+| [<< Step 1: Requirements](windows-requirements.md) | [Step 3: Server Setup >>](server-setup.md) |

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
 
 {% include callout.html content="Windows ≥ 10<br/>
 Boost ≥ 1.78<br/>
@@ -129,4 +129,4 @@ If you are still having problems, check:
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
+| [<< Start: Installation Guide](classic-installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |
 
 {% include callout.html content="Windows ≥ 10<br/>
 Boost ≥ 1.78<br/>
@@ -129,4 +129,4 @@ If you are still having problems, check:
 | Installation Guide                                                                                                                      |                                                      |
 | :-------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click on the previous link to easily move between the steps. |                                                      |
-| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](core-installation.md) |
+| [<< Start: Installation Guide](installation.md)                                                                                         | [Step 2: Core Installation >>](windows-core-installation.md) |


### PR DESCRIPTION
### Description
Installation
- Corrected Azerothcore Classic Installatinon to AzerothCore Classic Installatinon
- Changed AzerothCore Classic Installtion; Bash Dashboard and Docker Setup's Badges to be seperate from the hyperlink/path links of the Sources (removing the hyperlink space and badge's link) only allowing the text to be clickable.

DBC Index
-All the content of the index have been added the following re-direct to **how-to-import-dbc-data-in-db.md**

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

