### PR TITLE
Adjusted Installation Page and Added How To DBC Data onto Database on the DBC Indexes Pages

### DIFF
--- a/docs/achievement.md
+++ b/docs/achievement.md
@@ -9,8 +9,10 @@ redirect_from: "/Achievement"
 **Achievement.dbc**
 
 This DBC contains all achievements.
-
+    
  **Version is : 3.3.5a**
+
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/achievement_criteria.md
+++ b/docs/achievement_criteria.md
@@ -12,6 +12,8 @@ This DBC has been added with WoW 3.0.1.8303 and contains the needed criteria to
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field             | Type    | Notes                                                                |

--- a/docs/areatable.md
+++ b/docs/areatable.md
@@ -12,6 +12,8 @@ This DBC contains the zone and subzone lists. For the purposes of this wiki arti
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Name             | Type   | Notes                                                         |

--- a/docs/areatrigger.md
+++ b/docs/areatrigger.md
@@ -6,6 +6,8 @@
 
 This table contains trigger points for events in certain coordinates in the maps.
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)
+
 **Structure**
 
 | Field       | Type  | Attributes | Key | Null | Default | Extra          | Comment                                              |

--- a/docs/chrclasses.md
+++ b/docs/chrclasses.md
@@ -6,6 +6,8 @@ This DBC contains all possible player classes.
 
 **Version is 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ### Structure
 
 | Column | Name                                         | Type    | Notes                                                                                        |

--- a/docs/chrraces.md
+++ b/docs/chrraces.md
@@ -6,6 +6,8 @@ This DBC contains all possible races, some of which are unused and unavailable t
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ### Structure
 
 | Column | Field                   | Type         | Notes                                                                                |

--- a/docs/dbc-areatrigger.md
+++ b/docs/dbc-areatrigger.md
@@ -12,6 +12,8 @@ This DBC contains information about the triggers of the in-game areas.
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 

--- a/docs/emotes.md
+++ b/docs/emotes.md
@@ -8,6 +8,7 @@ redirect_from: "/Emotes"
 
 This DBC contains emotes which can be used by NPCs.
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/faction.md
+++ b/docs/faction.md
@@ -12,6 +12,7 @@ This DBC contains information on all of the base factions. These factions are un
 
 **IMPORTANT:** These values are used for **ALL** tables **EXCEPT** the [creature\_template](creature_template) and [gameobject\_template\_addon](gameobject_template_addon) tables.
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 

--- a/docs/factiontemplate.md
+++ b/docs/factiontemplate.md
@@ -12,6 +12,8 @@ This DBC contains information on all of the individual factions. A faction entry
 
 **IMPORTANT: These values are only used for the [creature\_template](creature_template) and [gameobject\_template](gameobject\_template) tables.**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## **Structure**
 
 | Field Nb | Name                                     | Type             |

--- a/docs/holidays.md
+++ b/docs/holidays.md
@@ -8,6 +8,8 @@ redirect_from: "/Holidays"
 
 [`Back-to:DBC`](dbc-index.md)
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field                         | Type    | Notes                                                                              | Extra info                                                                 |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,11 +12,11 @@ There are several ways to install AzerothCore, you need to choose **ONE**.
 
 These are the officially supported and complete ways of installing AzerothCore, for any purpose (Windows, Linux, macOS).
 
-- [Azerothcore Classic Installation <span class="badge badge-success">Recommended</span>](classic-installation.md) - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
+- [AzerothCore Classic Installation](classic-installation.md) <span class="badge badge-success">Recommended</span> - the traditional way of installing AzerothCore. Battle-tested, recommended for all operating systems for any purpose. This process gives more awareness of how AzerothCore is structured. See below on this page.
 
-- [AzerothCore Bash Dashboard setup <span class="badge badge-secondary">Limited Support</span>](ac-dashboard-core-installation.md) - the simplest way of installing AzerothCore, recommended for both local development and production.
+- [AzerothCore Bash Dashboard setup](ac-dashboard-core-installation.md) <span class="badge badge-secondary">Limited Support</span> - the simplest way of installing AzerothCore, recommended for both local development and production.
 
-- [Docker setup <span class="badge badge-secondary">Limited Support</span>](install-with-docker.md) - an installation process based on Docker. Docker knowledge is recommended.
+- [Docker setup](install-with-docker.md) <span class="badge badge-secondary">Limited Support</span> - an installation process based on Docker. Docker knowledge is recommended.
 
 ### Install from pre-compiled images <span class="badge badge-info">Limited support and usage</span>
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -6,6 +6,8 @@ redirect_from: "/Languages"
 
 [`Back-to:DBC`](dbc-index.md)
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 **DBC Structure - For Version 3.3.5a**
 
 This DBC contains languages that can be used in texts. The player must have competence in this language to understand what is written.

--- a/docs/map.md
+++ b/docs/map.md
@@ -12,6 +12,8 @@ This DBC contains the maps list.
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field                                                                                                                                                        | Type    | Notes                                                                                                     |

--- a/docs/pagetextmaterial.md
+++ b/docs/pagetextmaterial.md
@@ -12,6 +12,8 @@ This DBC contains material used to display a gossip window for quest or page tex
 
 **Version is : 3.1.3**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field   | Type    |

--- a/docs/skillline.md
+++ b/docs/skillline.md
@@ -12,6 +12,8 @@ This DBC contains all skills.
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## Structure
 
 | Column | Field                    | Type         | Notes              |

--- a/docs/spell.md
+++ b/docs/spell.md
@@ -13,6 +13,8 @@ These values are used by the core and a few spell\_\* tables.
 
 **Version 3.3.5**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 ## **Structure**
 
 | ID  | Name                          | Type   |

--- a/docs/summonproperties_dbc.md
+++ b/docs/summonproperties_dbc.md
@@ -10,6 +10,8 @@ This DBC contains Summon Properties (EffectMiscValueB) for Spell Effect SPELL_EF
 
 **Version is : 3.3.5a**
 
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
+
 **Structure**
 
 | Field                | Type | Attributes | Key | Null | Default | Extra | Comment                                                                          |

--- a/docs/totemcategory.md
+++ b/docs/totemcategory.md
@@ -7,7 +7,10 @@ redirect_from: "/TotemCategory"
 [`Back-to:DBC`](dbc-index.md)
 
 **TotemCategory.dbc**
+
 **Version is : 3.3.5a**
+
+[How to Import DBC Data onto my Database](how-to-import-dbc-data-in-db.md)  
 
 ## Structure
 


### PR DESCRIPTION
### Description
Installation
- Corrected Azerothcore Classic Installatinon to AzerothCore Classic Installatinon
- Changed AzerothCore Classic Installtion; Bash Dashboard and Docker Setup's Badges to be seperate from the hyperlink/path links of the Sources (removing the hyperlink space and badge's link) only allowing the text to be clickable.

DBC Index
-All the content of the index have been added the following re-direct to **how-to-import-dbc-data-in-db.md**

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

