### PR TITLE
Update how-to-test-db-only-changes.md

### DIFF
--- a/docs/how-to-test-db-only-changes.md
+++ b/docs/how-to-test-db-only-changes.md
@@ -62,7 +62,7 @@ After you test the changes, you need to return in a clean state (as you were bef
 
 - On a **traditional setup**, you can delete your `acore_world` database and use the DB assembler to generate a new one
 
-- On a **docker setup**, you can destroy and recreate your containers using `docker-compose down` and `docker-compose up`.
+- On a **docker setup**, you can drop the `acore_world` database via HeidiSQL, and run `docker compose up` inside the azerothcore-wotlk directory, and you will be prompted to re-create the `acore_world` database (press enter)
 
 ## Reports
 


### PR DESCRIPTION
Adjust docs when testing only db changes for Docker setup

### Description

- Using docker down / up only restarts the compilation of files, not the state of DB which is persisted on the volume
- 90% of the scripts required for testers / triagers are ran against acore_world


### Notes
- For spanish, I will use DeepL if you approve the current description