### PR TITLE
fix(linux-requirements): Debian: fix MYSQL installation steps

### DIFF
--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -40,7 +40,7 @@ sudo apt install -y install libboost1.74-dev
 #### Debian 12
 
 ```sh
-apt-get update && apt-get install -y git cmake make gcc g++ clang default-libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev libboost-all-dev lsb-release gnupg wget
+apt-get update && apt-get install -y git cmake make gcc g++ clang libssl-dev libbz2-dev libreadline-dev libncurses-dev libboost-all-dev lsb-release gnupg wget
 ```
 
 Remember that if you are using the `root` user, it is not necessary to use `sudo`.
@@ -57,7 +57,7 @@ Non-Interactive install using `DEBIAN_FRONTEND="noninteractive"` to install the 
 wget https://dev.mysql.com/get/mysql-apt-config_0.8.32-1_all.deb
 sudo DEBIAN_FRONTEND="noninteractive" dpkg -i ./mysql-apt-config_0.8.32-1_all.deb
 sudo apt-get update
-sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server
+sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server libmysqlclient-dev
 ```
 
 ---


### PR DESCRIPTION
- default-libmysqlclient-dev on Debian installs mariadb libraries
- therefore install libmysqlclient-dev via mysql software repository

<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

- 
- 

### Related Issue

Follow-Up to azerothcore/azerothcore-wotlk#20003
Closes azerothcore/azerothcore-wotlk#19999

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
