### PR TITLE
Remove priority tag section of triage guide.

### DIFF
--- a/docs/guide-to-triaging.md
+++ b/docs/guide-to-triaging.md
@@ -67,17 +67,6 @@ For the CC issue, you can tag it with 'Confirmed', 'Linked to AC', and a tag ind
 
 If you have the right permissions, also add the new AC issue to whichever project is relevant, usually the one matching the issue's level range.
 
-#### Priority Tags
-You can also set the perceived priority of an issue via tags. They are:
-
-| Tag Level | Description |
-|-----------|-------------|
-| **Critical** | Should only be used in the event of server-breaking bugs |
-| **High** | Game-breaking bugs with no workaround |
-| **Medium** | Game-breaking bugs that do have a workaround |
-| **Low** | More typical bugs with quests/items/NPCs, etc. Your 'standard' bug |
-| **Trivial** | Bugs that have no real impact on gameplay, typically cosmetic |
-
 ## Guidelines
 - **Use your judgement.** We are there to exercise our best judgement, not just as photocopiers. We have access to tools and information that most players don't, so we should be able to see more deeply into a problem than they can and make decisions accordingly.
 - **Generalize the problem.** Try to generalise or broaden a problem. If one unusual kind of item, NPC or spell is not working correctly, try checking other items of the same general type to see if they are broken as well. Ideally we want to capture the broadest possible range of errors that we can.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description
- Priority labels have long since been removed on the AzerothCore repository, the triage guide should reflect that.

### Related Issue
Closes unreported issue.

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
