### PR TITLE
Updated Requirements Boost Related

### DIFF
--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -8,7 +8,7 @@
 | |
 | :- |
 | [MySQL](https://github.com/azerothcore/azerothcore-wotlk/security/policy) |
-| Boost ≥ 1.74 |
+| Boost ≥ 1.74 up to 1.84 |
 | OpenSSL ≥ 3.0.x |
 | CMake ≥ 3.16 |
 | [OS](https://github.com/azerothcore/azerothcore-wotlk/security/policy) |

--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -8,7 +8,7 @@
 | |
 | :- |
 | [MySQL](https://github.com/azerothcore/azerothcore-wotlk/security/policy) |
-| Boost ≥ 1.74 up to 1.84 |
+| Boost ≥ 1.74 up to 1.85 |
 | OpenSSL ≥ 3.0.x |
 | CMake ≥ 3.16 |
 | [OS](https://github.com/azerothcore/azerothcore-wotlk/security/policy) |

--- a/docs/macos-requirements.md
+++ b/docs/macos-requirements.md
@@ -9,7 +9,7 @@
 | :------------ |
 | MacOS ≥ 11    |
 | OpenSSL ≥ 3.0 |
-| Boost ≥ 1.74 up to 1.84 |
+| Boost ≥ 1.74 up to 1.85 |
 | MySQL ≥ 8.0.0 |
 | CMake ≥ 3.16  |
 

--- a/docs/macos-requirements.md
+++ b/docs/macos-requirements.md
@@ -9,7 +9,7 @@
 | :------------ |
 | MacOS ≥ 11    |
 | OpenSSL ≥ 3.0 |
-| Boost ≥ 1.74  |
+| Boost ≥ 1.74 up to 1.84 |
 | MySQL ≥ 8.0.0 |
 | CMake ≥ 3.16  |
 

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -6,7 +6,7 @@
 | [<< Start: Installation Guide](classic-installation)                                                                                         | [Step 2: Core Installation >>](windows-core-installation) |
 
 {% include callout.html content="Windows ≥ 10<br/>
-Boost ≥ 1.78<br/>
+Boost ≥ 1.78 up to 1.84<br/>
 MySQL ≥ 8.0 (Recommended 8.4)<br/>
 OpenSSL ≥ 3.x.x<br/>
 CMake ≥ 3.16<br/>
@@ -90,9 +90,9 @@ MS Visual Studio (Community) ≥ 17 (2022) (Desktop) (No preview)" type="info" %
     While installing OpenSSL, choose The OpenSSL binaries (/bin) directory (NOT "The Windows system directory") when given the choice of where to copy the OpenSSL DLLs. These DLLs will need to be located easily for <a href="windows-core-installation">Core Installation</a>.
     {{site.data.alerts.end}}
 
-8. [Boost](https://www.boost.org/).
+8. [Boost](https://boostorg.jfrog.io/artifactory/main/release/).
 
-    1. Download the prebuilt Windows Binary for Visual Studio 2022. [64bit](https://sourceforge.net/projects/boost/files/boost-binaries/1.81.0/boost_1_81_0-msvc-14.3-64.exe/download)
+    1. Download the prebuilt Windows Binary for Visual Studio 2022. [64bit, this version is 1.81 msvc 14.3](https://sourceforge.net/projects/boost/files/boost-binaries/1.81.0/boost_1_81_0-msvc-14.3-64.exe/download).
 
     2. Add an environment variable to the "System" variable named "BOOST_ROOT" and with the value being your Boost installation directory, e.g. `C:/local/boost_1_81_0`. Important is to use '**/**', not '**\\**'  when pointing to the directory. (Make sure that it does not have a trailing slash (end of the path). If you still get problems, add the same variable in the `USER` variables section too, as shown in the image below.)
 

--- a/docs/windows-requirements.md
+++ b/docs/windows-requirements.md
@@ -6,7 +6,7 @@
 | [<< Start: Installation Guide](classic-installation)                                                                                         | [Step 2: Core Installation >>](windows-core-installation) |
 
 {% include callout.html content="Windows ≥ 10<br/>
-Boost ≥ 1.78 up to 1.84<br/>
+Boost ≥ 1.78 up to 1.85<br/>
 MySQL ≥ 8.0 (Recommended 8.4)<br/>
 OpenSSL ≥ 3.x.x<br/>
 CMake ≥ 3.16<br/>


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

Updated Boost Requirements

From >= 1.78 to >= 1.78 up to 1.84 (for windows, linux and macos)
It seems others higher than .84 give errors. (windows only mentioned issue)

Updated the Boost header download to go to downloads of the versions instead of confusing the user with the "Most" recent version. (windows)

Also updated the msvc text to say which version of boost and msvc is being downloaded. (windows)

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
