### PR TITLE
fix: link to cc server info

### DIFF
--- a/docs/es/guide-to-triaging.md
+++ b/docs/es/guide-to-triaging.md
@@ -140,5 +140,5 @@ Wowpedia a menudo agrega notas de parche relacionadas con un talento o habilidad
 ## Otros enlaces
 
 - [Versión actual de ChromieCraft](https://github.com/chromiecraft/azerothcore-wotlk)
-- [Mods de ChromieCraft](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO)
+- [Mods de ChromieCraft](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO.md)
 - [Cómo hacer la evaluación de errores](https://github.com/chromiecraft/chromiecraft#for-contributors-how-to-triagereport-bugs)

--- a/docs/es/guide-to-triaging.md
+++ b/docs/es/guide-to-triaging.md
@@ -140,5 +140,5 @@ Wowpedia a menudo agrega notas de parche relacionadas con un talento o habilidad
 ## Otros enlaces
 
 - [Versión actual de ChromieCraft](https://github.com/chromiecraft/azerothcore-wotlk)
-- [Mods de ChromieCraft](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO.md)
+- [Mods de ChromieCraft](https://github.com/chromiecraft/chromiecraft/blob/main/.github/CC_SERVER_INFO.md)
 - [Cómo hacer la evaluación de errores](https://github.com/chromiecraft/chromiecraft#for-contributors-how-to-triagereport-bugs)

--- a/docs/guide-to-triaging.md
+++ b/docs/guide-to-triaging.md
@@ -126,5 +126,5 @@ This is a general (and by no means exhaustive) look at the sources we can use to
 
 ## Other Links
 - [Current ChromieCraft version](https://github.com/chromiecraft/azerothcore-wotlk)
-- [ChromieCraft mods](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO)
+- [ChromieCraft mods](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO.md)
 - [How to triage](https://github.com/chromiecraft/chromiecraft#for-contributors-how-to-triagereport-bugs)

--- a/docs/guide-to-triaging.md
+++ b/docs/guide-to-triaging.md
@@ -126,5 +126,5 @@ This is a general (and by no means exhaustive) look at the sources we can use to
 
 ## Other Links
 - [Current ChromieCraft version](https://github.com/chromiecraft/azerothcore-wotlk)
-- [ChromieCraft mods](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO.md)
+- [ChromieCraft mods](https://github.com/chromiecraft/chromiecraft/blob/main/.github/CC_SERVER_INFO.md)
 - [How to triage](https://github.com/chromiecraft/chromiecraft#for-contributors-how-to-triagereport-bugs)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

https://www.azerothcore.org/wiki/guide-to-triaging
Other links -> [ChromieCraft mods](https://raw.githubusercontent.com/chromiecraft/chromiecraft/main/.github/CC_SERVER_INFO)

404: Not Found

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
