### PR TITLE
(fix): Changing URL to lower case to fix HTTP 404 in page

### DIFF
--- a/docs/es/the-modular-structure.md
+++ b/docs/es/the-modular-structure.md
@@ -10,7 +10,7 @@ El resultado es tener siempre un núcleo limpio que es fácil de mantener y mant
 
 Para cambiar las características del juego, los módulos utilizan **script hooks**, que son una colección de funciones [implementadas en el núcleo: ScriptMgr.h](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Scripting/ScriptMgr.h) y son capaces de operar desde el principio del servidor (tan pronto como comienza la inicialización del Mundo).
 
-La lista de los hooks de scripts está disponible [aquí](Hooks-Script).
+La lista de los hooks de scripts está disponible [aquí](hooks-script).
 
 A veces necesitas añadir nuevos hooks para tu módulo personalizado, es absolutamente posible añadirlos al núcleo. Sólo hay unos pocos pasos necesarios para crear un nuevo hook, por favor, siga esta guía [aquí](hooks-script) para aprender cómo.
 

--- a/docs/the-modular-structure.md
+++ b/docs/the-modular-structure.md
@@ -14,7 +14,7 @@ This results in always having a clean core that is easy to maintain and to keep 
 
 In order to change game features, modules use **script hooks**, which are a collection of functions [implemented into the core](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Scripting/ScriptMgr.h) and are able to operate from the very beginning of the server (as soon as the World initialization starts).
 
-The list of the script hooks is available [here](Hooks-Script).
+The list of the script hooks is available [here](hooks-script).
 
 Sometimes you need to add new hooks for your custom module, it's absolutely possible to add them to the core. There are just a few steps needed in order to create a new hook, please follow this guide [here](hooks-script) to learn how.
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description
When trying to access the documentation about Script hooks in the file the-modular-structure.md Github returns a HTTP 404. I noticed the file that is trying to find is using the first letter capitalized, and since GitHub's file linking is case-sensitive I am opening this PR to fix the documentation.

- 
- 

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
