### PR TITLE
make server-setup only link to OS-server-setup

### DIFF
--- a/docs/es/linux-core-installation.md
+++ b/docs/es/linux-core-installation.md
@@ -3,7 +3,7 @@
 | Guía de Instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de Instalación. Puede leerlo solo o hacer click en los links previos para navegar con facilidad entre los pasos. |
-| [<< Paso 1: Requisitos](linux-requirements) | [Paso 3: Instalación del Servidor >>](linux-server-setup) |
+| [<< Paso 1: Requisitos](linux-requirements) | [Paso 3: Instalación del Servidor >>](server-setup) |
 
 ## Software requerido
 
@@ -207,4 +207,4 @@ If you are still having problems, check:
 | Installation Guide | |
 | :- | :- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](linux-requirements) | [Step 3: Server Setup >>](linux-server-setup) |
+| [<< Step 1: Requirements](linux-requirements) | [Step 3: Server Setup >>](server-setup) |

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                   |                                               |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](server-setup) |
+| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](linux-server-setup) |
 
 ## Installation directories
 
@@ -200,4 +200,4 @@ sudo journalctl ac-worldserver.service
 | Installation Guide                                                                                                                   |                                               |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](server-setup) |
+| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](linux-server-setup) |

--- a/docs/linux-core-installation.md
+++ b/docs/linux-core-installation.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                   |                                               |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](linux-server-setup) |
+| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](server-setup) |
 
 ## Installation directories
 
@@ -200,4 +200,4 @@ sudo journalctl ac-worldserver.service
 | Installation Guide                                                                                                                   |                                               |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](linux-server-setup) |
+| [<< Step 1: Requirements](linux-requirements)                                                                                        | [Step 3: Server Setup >>](server-setup) |

--- a/docs/linux-server-setup.md
+++ b/docs/linux-server-setup.md
@@ -40,7 +40,7 @@ If you intend to use an enUS client you can download the data files below. If yo
 
 **(Not needed if you downloaded the files above)**
 
-Go to your AzerothCore build directory (e.g. $HOME/build/bin/) and copy the following files to your World of Warcraft binaries directory.
+Go to your AzerothCore build directory (e.g. $AC_CODE_DIR/env/dist/) and copy the following files to your World of Warcraft binaries directory.
 
 * **map_extractor**
 * **mmaps_generator**

--- a/docs/linux-server-setup.md
+++ b/docs/linux-server-setup.md
@@ -6,11 +6,11 @@
 | [<< Step 2: Core Installation](linux-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
 **Table of contents**
-- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
-- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
-- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
+- [Client Data Files (Download Pre-Extracted)](#option-1-download-pre-extracted-files)
+- [Client Data Extractors (Extract Files Yourself)](#option-2-extract-files-yourself)
+- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver)
 
-Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
+Now that you have the source compiled, you need to add the necessary client data. You can either download pre-extracted files or use the compiled extractors to extract the files yourself. Once the data is ready, you must update the **DataDir** option in your **worldserver.conf** file to point to the directory containing the data.
 
 Some files are optional but highly recommended:
 
@@ -22,21 +22,22 @@ Some files are optional but highly recommended:
 | mmaps     | HIGHLY RECOMMENDED |
 | cameras   | Recommended        |
 
-## Data files
+## Option 1: Download Pre-Extracted Files
 
-If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
+
+If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#option-2-extract-files-yourself) the data yourself.
 
 <a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
 
 1. Download the files above.
 
-2. Create a new folder within the build folder called **Data**. i.e **$HOME/azerothcore/data/**
+2. Create a new folder within the build folder called **data**. i.e **$AC_CODE_DIR/build/data/**
 
-3. Extract the files from the zip file and place them within the **Data** folder.
+3. Extract the files from the zip file and place them within the **data** folder.
 
 4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
 
-## Extractors
+## Option 2: Extract Files Yourself
 
 **(Not needed if you downloaded the files above)**
 
@@ -88,11 +89,11 @@ mkdir mmaps;
 ./mmaps_generator
 ```
 
-Now that everything is completed, you need to copy **dbc**, **maps**, **vmaps** and **mmaps** folders to your AzerothCore build directory (e.g. *$HOME/build/data/*).
+Now that everything is completed, you need to copy **dbc**, **maps**, **vmaps** and **mmaps** folders to your AzerothCore build directory (e.g. **$AC_CODE_DIR/build/data/**.
 
 ## Config Files: Worldserver and Authserver
 
-First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/configs/ (may vary).
+First of all you need to find the two default config files (named **worldserver.conf.dist** and **authserver.conf.dist**) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/configs/ (may vary).
 
 Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
 
@@ -123,11 +124,11 @@ The following steps must be verified:
 
 ### Updating DataDir
 
-1. In your worldserver.conf file locate the **DataDir** option.
+1. In your **worldserver.conf** file locate the **DataDir** option.
 
 1. Edit it to the path of your folder. i.e **$HOME/azerothcore/data/**
 
-{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
+{% include tip.html content="For most **worldserver.conf** setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
 
 {% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
 

--- a/docs/linux-server-setup.md
+++ b/docs/linux-server-setup.md
@@ -3,9 +3,42 @@
 | Installation Guide                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
+| [<< Step 2: Core Installation](linux-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
-## Extracting DBC, Maps, VMaps & MMaps
+**Table of contents**
+- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
+- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
+- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
+
+Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
+
+Some files are optional but highly recommended:
+
+| Directory |                    |
+| :-------- | :----------------- |
+| dbc       | Mandatory          |
+| maps      | Mandatory          |
+| vmaps     | HIGHLY RECOMMENDED |
+| mmaps     | HIGHLY RECOMMENDED |
+| cameras   | Recommended        |
+
+## Data files
+
+If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
+
+<a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
+
+1. Download the files above.
+
+2. Create a new folder within the build folder called **Data**. i.e **$HOME/azerothcore/data/**
+
+3. Extract the files from the zip file and place them within the **Data** folder.
+
+4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
+
+## Extractors
+
+**(Not needed if you downloaded the files above)**
 
 Go to your AzerothCore build directory (e.g. $HOME/build/bin/) and copy the following files to your World of Warcraft binaries directory.
 
@@ -57,7 +90,7 @@ mkdir mmaps;
 
 Now that everything is completed, you need to copy **dbc**, **maps**, **vmaps** and **mmaps** folders to your AzerothCore build directory (e.g. *$HOME/build/data/*).
 
-## Setting up the configuration files
+## Config Files: Worldserver and Authserver
 
 First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/configs/ (may vary).
 
@@ -76,7 +109,31 @@ They follow this structure:
 Variablename = "MySQLIP;Port;Username;Password;database"  
 ``` 
 
-<br>
+The following steps must be verified:
+
+- The hostname (127.0.0.1) can stay the same if AzerothCore is being installed on the same computer that you run WoW on.
+  If not, follow the instruction in [Realmlist Table](realmlist).
+
+- The port (3306) is the standard configured value. If you changed the default port in your MySQL settings, you must change it accordingly.
+  The username and password can be variable. You can choose to either: 
+
+    - use default acore / acore username and password pair.
+
+    - create a unique login within a User Manager within your preferred database management tool (commonly identified by an icon that looks like a person or people) and give it the necessary permissions (SELECT, INSERT, UPDATE, DELETE permissions are sufficient, and is much safer).
+
+### Updating DataDir
+
+1. In your worldserver.conf file locate the **DataDir** option.
+
+1. Edit it to the path of your folder. i.e **$HOME/azerothcore/data/**
+
+{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
+
+{% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
+
+### (Optional) Config options by environment variable
+
+It is possible to load config options via environment variables, which you can read about [here](config-overrides-with-env-var).
 
 ## Help
 
@@ -85,4 +142,4 @@ Variablename = "MySQLIP;Port;Username;Password;database"
 | Installation Guide                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
+| [<< Step 2: Core Installation](linux-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |

--- a/docs/macos-core-installation.md
+++ b/docs/macos-core-installation.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                   |                                         |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](macos-requirements)                                                                                        | [Step 3: Server Setup >>](server-setup) |
+| [<< Step 1: Requirements](macos-requirements)                                                                                        | [Step 3: Server Setup >>](macos-server-setup) |
 
 ## Required software
 
@@ -107,4 +107,4 @@ make install
 | Installation Guide                                                                                                                   |                                         |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](macos-requirements)                                                                                        | [Step 3: Server Setup >>](server-setup) |
+| [<< Step 1: Requirements](macos-requirements)                                                                                        | [Step 3: Server Setup >>](macos-server-setup) |

--- a/docs/macos-server-setup.md
+++ b/docs/macos-server-setup.md
@@ -6,11 +6,11 @@
 | [<< Step 2: Core Installation](macos-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
 **Table of contents**
-- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
-- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
-- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
+- [Client Data Files (Download Pre-Extracted)](#option-1-download-pre-extracted-files)
+- [Client Data Extractors (Extract Files Yourself)](#option-2-extract-files-yourself)
+- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver)
 
-Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
+Now that you have the source compiled, you need to add the necessary client data. You can either download pre-extracted files or use the compiled extractors to extract the files yourself. Once the data is ready, you must update the **DataDir** option in your **worldserver.conf** file to point to the directory containing the data.
 
 Some files are optional but highly recommended:
 
@@ -22,25 +22,25 @@ Some files are optional but highly recommended:
 | mmaps     | HIGHLY RECOMMENDED |
 | cameras   | Recommended        |
 
-## Data files
+## Option 1: Download Pre-Extracted Files
 
-If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
+If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#option-2-extract-files-yourself) the data yourself.
 
 <a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
 
 1. Download the files above.
 
-2. Create a new folder within the build folder called **Data**. i.e. **$HOME/azeroth-server/data/**
+2. Create a new folder within the build folder called **data**. i.e. **$HOME/azeroth-server/data/**
 
-3. Extract the files from the zip file and place them within the **Data** folder.
+3. Extract the files from the zip file and place them within the **data** folder.
 
 4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
 
-## Extractors
+## Option 2: Extract Files Yourself
 
 **(Not needed if you downloaded the files above)**
 
-Go to your AzerothCore build directory (e.g. $HOME/build/bin/) and copy the following files to your World of Warcraft binaries directory.
+Go to your AzerothCore build directory (e.g. $HOME/azeroth-server/bin/) and copy the following files to your World of Warcraft binaries directory.
 
 * **mapextractor**
 * **mmaps_generator**
@@ -88,11 +88,11 @@ mkdir mmaps;
 ./mmaps_generator
 ```
 
-Now that everything is completed, you need to copy **dbc**, **maps**, **vmaps** and **mmaps** folders to your AzerothCore build directory (e.g. *$HOME/build/data/*).
+Now that everything is completed, you need to copy **dbc**, **maps**, **vmaps** and **mmaps** folders to your AzerothCore build directory (e.g. **$HOME/azeroth-server/data/**).
 
 ## Config Files: Worldserver and Authserver
 
-First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/configs/ (may vary).
+First of all you need to find the two default config files (named **worldserver.conf.dist** and **authserver.conf.dist**) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/configs/ (may vary).
 
 Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
 
@@ -123,11 +123,11 @@ The following steps must be verified:
 
 ### Updating DataDir
 
-1. In your worldserver.conf file locate the **DataDir** option.
+1. In your **worldserver.conf** file locate the **DataDir** option.
 
 1. Edit it to the path of your folder. i.e **$HOME/azeroth-server/data/**
 
-{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
+{% include tip.html content="For most **worldserver.conf** setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
 
 {% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
 

--- a/docs/macos-server-setup.md
+++ b/docs/macos-server-setup.md
@@ -3,9 +3,42 @@
 | Installation Guide                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
+| [<< Step 2: Core Installation](macos-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
-## Extracting DBC, Maps, VMaps & MMaps
+**Table of contents**
+- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
+- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
+- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
+
+Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
+
+Some files are optional but highly recommended:
+
+| Directory |                    |
+| :-------- | :----------------- |
+| dbc       | Mandatory          |
+| maps      | Mandatory          |
+| vmaps     | HIGHLY RECOMMENDED |
+| mmaps     | HIGHLY RECOMMENDED |
+| cameras   | Recommended        |
+
+## Data files
+
+If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
+
+<a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
+
+1. Download the files above.
+
+2. Create a new folder within the build folder called **Data**. i.e. **$HOME/azeroth-server/data/**
+
+3. Extract the files from the zip file and place them within the **Data** folder.
+
+4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
+
+## Extractors
+
+**(Not needed if you downloaded the files above)**
 
 Go to your AzerothCore build directory (e.g. $HOME/build/bin/) and copy the following files to your World of Warcraft binaries directory.
 
@@ -57,7 +90,7 @@ mkdir mmaps;
 
 Now that everything is completed, you need to copy **dbc**, **maps**, **vmaps** and **mmaps** folders to your AzerothCore build directory (e.g. *$HOME/build/data/*).
 
-## Setting up the configuration files
+## Config Files: Worldserver and Authserver
 
 First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/configs/ (may vary).
 
@@ -76,7 +109,31 @@ They follow this structure:
 Variablename = "MySQLIP;Port;Username;Password;database"  
 ``` 
 
-<br>
+The following steps must be verified:
+
+- The hostname (127.0.0.1) can stay the same if AzerothCore is being installed on the same computer that you run WoW on.
+  If not, follow the instruction in [Realmlist Table](realmlist).
+
+- The port (3306) is the standard configured value. If you changed the default port in your MySQL settings, you must change it accordingly.
+  The username and password can be variable. You can choose to either: 
+
+    - use default acore / acore username and password pair.
+
+    - create a unique login within a User Manager within your preferred database management tool (commonly identified by an icon that looks like a person or people) and give it the necessary permissions (SELECT, INSERT, UPDATE, DELETE permissions are sufficient, and is much safer).
+
+### Updating DataDir
+
+1. In your worldserver.conf file locate the **DataDir** option.
+
+1. Edit it to the path of your folder. i.e **$HOME/azeroth-server/data/**
+
+{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
+
+{% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
+
+### (Optional) Config options by environment variable
+
+It is possible to load config options via environment variables, which you can read about [here](config-overrides-with-env-var).
 
 ## Help
 
@@ -85,4 +142,4 @@ Variablename = "MySQLIP;Port;Username;Password;database"
 | Installation Guide                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
+| [<< Step 2: Core Installation](macos-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -5,133 +5,13 @@
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
 | [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
-**Table of contents**
-- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
-- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
-- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
-
-Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
-
-Some files are optional but highly recommended:
-
-| Directory |                    |
-| :-------- | :----------------- |
-| dbc       | Mandatory          |
-| maps      | Mandatory          |
-| vmaps     | HIGHLY RECOMMENDED |
-| mmaps     | HIGHLY RECOMMENDED |
-| cameras   | Recommended        |
-
-## Data files
-
-If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
-
-<a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
-
-1. Download the files above.
-
-2. Create a new folder within the build folder called **Data**. i.e windows: **C:\Build\bin\RelWithDebInfo\Data** or Linux: **$HOME/azerothcore/data/**
-
-3. Extract the files from the zip file and place them within the **Data** folder.
-
-4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
-
-## Extractors
-
-**(Not needed if you downloaded the files above)**
-
-If you downloaded the files above you can skip this step and jump forward to [worldserver.conf and authserver.conf](#config-files-worldserver-and-authserver).
-
-This part is just a general summary of the overall process - please read it in more detail for the OS you are working with.
-
 [Linux Server Setup](linux-server-setup)
 
 [macOS Server Setup](macos-server-setup)
 
 [Windows Server Setup](windows-server-setup)
 
-AzerothCore needs certain files extracted from the World of Warcraft client. You need to extract them from a 3.3.5a client.
-
-By default, you will compile your core with tools and you will get the following executable files: **mapextractor**, **vmap4extractor**, **vmap4assembler**, **mmaps_generator** (.exe on Windows).
-
-Place the files with your World of Warcraft binary (wow.exe on Windows) and run them.
-
-After extracting all necessary files, create a folder called **Data** within the **RelWithDebInfo** or **Debug** directory and place the files in there. Alternatively, you can specify a different directory where you want to keep them by changing the DataDir value in the worldserver.conf file.
-
-If you use extractors from other projects or branches it is almost certain that your AzerothCore will not recognize the extracted data or even work!
-
-When this is complete you may receive the following message which can be safely ignored:
-
-```
-Processing Map 724
-[################################################################]
-Extracting GameObject models...Extracting World\Wmo\Band\Final_Stage.wmo
-No such file.
-Couldn't open RootWmo!!!
-Done!
-  
-Extract V4.00 2012_02. Work complete. No errors.
-```
-
-### Trouble Shooting
-
-"**Unable to open wmo_list.txt! Nothing extracted.**"
-
-You need to run Mapextractor.exe before the makevmaps_simple.bat.
-
-## Config Files: Worldserver and Authserver
-
-Every time the core is recompiled a distributed, .dist, conf file will be made where all the default options are stored. This file serves no real purpose except for distributing all the options from the core.
-
-### Creating the config files
-
-1. Go to your configs folder i.e. D:\build\bin\RelWithDebInfo\configs
-
-1. Remove the **.dist** part from **worldserver.conf.dist** and **authserver.conf.dist**.
-
-    - You should be left with **worldserver.conf** and **authserver.conf**.
-
-Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
-
-On a newly compiled configuration, you will have the following values by default
-
-```
-LoginDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_auth"         -> worldserver.conf / authserver.conf
-WorldDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_world"        -> worldserver.conf
-CharacterDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_characters"   -> worldserver.conf
-```
-
-That part of the configuration follows this specific format or structure:
-
-```
-Variablename = "MySQLIP;Port;Username;Password;database"  
-``` 
-
-The following steps must be verified:
-
-- The hostname (127.0.0.1) can stay the same if AzerothCore is being installed on the same computer that you run WoW on.
-  If not, follow the instruction in [Realmlist Table](realmlist).
-
-- The port (3306) is the standard configured value. If you changed the default port in your MySQL settings, you must change it accordingly.
-  The username and password can be variable. You can choose to either: 
-
-    - use default acore / acore username and password pair.
-
-    - create a unique login within a User Manager within your preferred database management tool (commonly identified by an icon that looks like a person or people) and give it the necessary permissions (SELECT, INSERT, UPDATE, DELETE permissions are sufficient, and is much safer).
-
-### Updating DataDir
-
-1. In your worldserver.conf file locate the **DataDir** option.
-
-1. Edit it to the path of your folder. i.e **C:\Build\bin\RelWithDebInfo\Data**
-
-{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
-
-{% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
-
-### (Optional) Config options by environment variable
-
-It is possible to load config options via environment variables, which you can read about [here](config-overrides-with-env-var).
+<br>
 
 ## Help
 

--- a/docs/windows-core-installation.md
+++ b/docs/windows-core-installation.md
@@ -3,7 +3,7 @@
 | Installation Guide                                                                                                                   |                                         |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](windows-requirements)                                                                                      | [Step 3: Server Setup >>](server-setup) |
+| [<< Step 1: Requirements](windows-requirements)                                                                                      | [Step 3: Server Setup >>](windows-server-setup) |
 
 ## Required software
 
@@ -134,4 +134,4 @@ pdb files only exist if you compile with Debug or RelWithDebInfo configuration. 
 | Installation Guide                                                                                                                   |                                         |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 1: Requirements](windows-requirements)                                                                                      | [Step 3: Server Setup >>](server-setup) |
+| [<< Step 1: Requirements](windows-requirements)                                                                                      | [Step 3: Server Setup >>](windows-server-setup) |

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -3,9 +3,42 @@
 | Installation Guide                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
+| [<< Step 2: Core Installation](windows-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
-## Extracting DBC, Maps, VMaps & MMaps
+**Table of contents**
+- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
+- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
+- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
+
+Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
+
+Some files are optional but highly recommended:
+
+| Directory |                    |
+| :-------- | :----------------- |
+| dbc       | Mandatory          |
+| maps      | Mandatory          |
+| vmaps     | HIGHLY RECOMMENDED |
+| mmaps     | HIGHLY RECOMMENDED |
+| cameras   | Recommended        |
+
+## Data files
+
+If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
+
+<a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
+
+1. Download the files above.
+
+2. Create a new folder within the build folder called **Data**. i.e **C:\Build\bin\RelWithDebInfo\Data**
+
+3. Extract the files from the zip file and place them within the **Data** folder.
+
+4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
+
+## Extractors
+
+**(Not needed if you downloaded the files above)**
 
 1. Browse into your build directory (**C:\Build\bin\RelWithDebInfo\\**) and copy the following files into your World of Warcraft folder (where the wow.exe is located).
 ```
@@ -39,9 +72,9 @@ vmap4assembler.exe
 
 6. Move the vmaps, maps, dbc, cameras into the <b>Data</b> folder.
 
-## Setting up the configuration files
+## Config Files: Worldserver and Authserver
 
-First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within /build/bin/configs/ (may vary).
+First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within C:\Build\bin\RelWithDebInfo\configs\ (may vary).
 
 Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
 
@@ -58,7 +91,31 @@ They follow this structure:
 Variablename = "MySQLIP;Port;Username;Password;database"  
 ``` 
 
-<br>
+The following steps must be verified:
+
+- The hostname (127.0.0.1) can stay the same if AzerothCore is being installed on the same computer that you run WoW on.
+  If not, follow the instruction in [Realmlist Table](realmlist).
+
+- The port (3306) is the standard configured value. If you changed the default port in your MySQL settings, you must change it accordingly.
+  The username and password can be variable. You can choose to either: 
+
+    - use default acore / acore username and password pair.
+
+    - create a unique login within a User Manager within your preferred database management tool (commonly identified by an icon that looks like a person or people) and give it the necessary permissions (SELECT, INSERT, UPDATE, DELETE permissions are sufficient, and is much safer).
+
+### Updating DataDir
+
+1. In your worldserver.conf file locate the **DataDir** option.
+
+1. Edit it to the path of your folder. i.e **C:\Build\bin\RelWithDebInfo\Data**
+
+{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
+
+{% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
+
+### (Optional) Config options by environment variable
+
+It is possible to load config options via environment variables, which you can read about [here](config-overrides-with-env-var).
 
 ## Help
 
@@ -67,4 +124,4 @@ Variablename = "MySQLIP;Port;Username;Password;database"
 | Installation Guide                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
-| [<< Step 2: Core Installation](core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
+| [<< Step 2: Core Installation](windows-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -6,11 +6,11 @@
 | [<< Step 2: Core Installation](windows-core-installation)                                                                                    | [Step 4: Database Installation >>](database-installation) |
 
 **Table of contents**
-- [Data files](#data-files) - Required/Optional (Not needed if you extract the files.)
-- [Extractors](#extractors) - Required/Optional (Not needed if you download the files.)
-- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver) - Required
+- [Client Data Files (Download Pre-Extracted)](#option-1-download-pre-extracted-files)
+- [Client Data Extractors (Extract Files Yourself)](#option-2-extract-files-yourself)
+- [Config Files: Worldserver and Authserver](#config-files-worldserver-and-authserver)
 
-Now that you have the source compiled, you need to add some necessary files, by either downloading or extracting them.
+Now that you have the source compiled, you need to add the necessary client data. You can either download pre-extracted files or use the compiled extractors to extract the files yourself. Once the data is ready, you must update the **DataDir** option in your **worldserver.conf** file to point to the directory containing the data.
 
 Some files are optional but highly recommended:
 
@@ -22,9 +22,9 @@ Some files are optional but highly recommended:
 | mmaps     | HIGHLY RECOMMENDED |
 | cameras   | Recommended        |
 
-## Data files
+## Option 1: Download Pre-Extracted Files
 
-If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#extractors) the data yourself.
+If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#option-2-extract-files-yourself) the data yourself.
 
 <a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
 
@@ -36,7 +36,7 @@ If you intend to use an enUS client you can download the data files below. If yo
 
 4. Edit your the [DataDir](#updating-datadir) config option to the location of your folder.
 
-## Extractors
+## Option 2: Extract Files Yourself
 
 **(Not needed if you downloaded the files above)**
 
@@ -74,7 +74,7 @@ vmap4assembler.exe
 
 ## Config Files: Worldserver and Authserver
 
-First of all you need to find the two default config files (named worldserver.conf.dist and authserver.conf.dist) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within C:\Build\bin\RelWithDebInfo\configs\ (may vary).
+First of all you need to find the two default config files (named **worldserver.conf.dist** and **authserver.conf.dist**) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within C:\Build\bin\RelWithDebInfo\configs\ (may vary).
 
 Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
 
@@ -105,11 +105,11 @@ The following steps must be verified:
 
 ### Updating DataDir
 
-1. In your worldserver.conf file locate the **DataDir** option.
+1. In your **worldserver.conf** file locate the **DataDir** option.
 
 1. Edit it to the path of your folder. i.e **C:\Build\bin\RelWithDebInfo\Data**
 
-{% include tip.html content="For most worldserver.conf setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
+{% include tip.html content="For most **worldserver.conf** setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
 
 {% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

There are many support questions in discord with issues on the server starting that stem from incorrect DataDir paths/missing client Data altogether. Most of these are from linux users. I think this comes from linux users getting an incomplete explanation of the client data
The Windows and MacOs core installation pages also link to the general server setup page

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
