### PR TITLE
Smallint

### DIFF
--- a/docs/game_event_creature.md
+++ b/docs/game_event_creature.md
@@ -1,30 +1,29 @@
-# game\_event\_creature
+# game_event_creature
 
 [<-Back-to:World](database-world)
 
-**The \`game\_event\_creature\` table**
+**The \`game_event_creature\` table**
 
 Contains all creature instances that have to be spawned/unspawned during defined game events.
 
 **Table Structure**
 
-| Field           | Type    | Attributes | Key | Null | Default | Extra  | Comment                                                             |
-| --------------- | ------- | ---------- | --- | ---- | ------- | ------ | ------------------------------------------------------------------- |
-| [eventEntry][1] | TINYINT | SIGNED     |     | NO   |         |        | Entry of the game event. Put negative entry to remove during event. |
-| [guid][2]       | INT     | UNSIGNED   | PRI | NO   |         | Unique |                                                                     |
-
-[1]: #evententry
-[2]: #guid
+| Field                     | Type     | Attributes | Key | Null | Default | Extra  | Comment                                                             |
+| ------------------------- | -------- | ---------- | --- | ---- | ------- | ------ | ------------------------------------------------------------------- |
+| [eventEntry](#evententry) | SMALLINT | SIGNED     |     | NO   |         |        | Entry of the game event. Put negative entry to remove during event. |
+| [guid](#guid)             | INT      | UNSIGNED   | PRI | NO   |         | Unique |                                                                     |
 
 **Description of the fields**
 
 ### eventEntry
 
-Entry of the event (game\_event.entry)
+Refers to: [game_event.entry](#game_event.entry).
 
-**Use**+\*entry to have the creature added during the event
-**Use**-\*entry to have it removed during the event
+Using a **positve** number will **add** the creature to the event when is running.
+
+Using a **negative** number will **remove** the creature to the event when is running.
+
 
 ### guid
 
-Guid of the creature participating in the event (creature.guid)
+Refers to: [creature.guid](#creature.guid).

--- a/docs/game_event_creature.md
+++ b/docs/game_event_creature.md
@@ -17,7 +17,7 @@ Contains all creature instances that have to be spawned/unspawned during defined
 
 ### eventEntry
 
-Refers to: [game_event.entry](#game_event.entry).
+Refers to: [game_event.entry](game_event#entry).
 
 Using a **positve** number will **add** the creature to the event when is running.
 
@@ -25,4 +25,4 @@ Using a **negative** number will **remove** the creature to the event when is ru
 
 ### guid
 
-Refers to: [creature.guid](#creature.guid).
+Refers to: [creature.guid](creature#guid).

--- a/docs/game_event_creature.md
+++ b/docs/game_event_creature.md
@@ -23,7 +23,6 @@ Using a **positve** number will **add** the creature to the event when is runnin
 
 Using a **negative** number will **remove** the creature to the event when is running.
 
-
 ### guid
 
 Refers to: [creature.guid](#creature.guid).

--- a/docs/game_event_gameobject.md
+++ b/docs/game_event_gameobject.md
@@ -1,30 +1,28 @@
-# game\_event\_gameobject
+# game_event_gameobject
 
 [<-Back-to:World](database-world)
 
-**The \`game\_event\_gameobject\` table**
+**The \`game_event_gameobject\` table**
 
 Contains all gameobjects instances that participate to any game event.
 
 **Table Structure**
 
-| Field           | Type    | Attributes | Key | Null | Default | Extra  | Comment                                                             |
-| --------------- | ------- | ---------- | --- | ---- | ------- | ------ | ------------------------------------------------------------------- |
-| [eventEntry][1] | TINYINT | SIGNED     |     | NO   |         |        | Entry of the game event. Put negative entry to remove during event. |
-| [guid][2]       | INT     | UNSIGNED   | PRI | NO   |         | Unique |                                                                     |
-
-[1]: #evententry
-[2]: #guid
+| Field                     | Type     | Attributes | Key | Null | Default | Extra  | Comment                                                             |
+| ------------------------- | -------- | ---------- | --- | ---- | ------- | ------ | ------------------------------------------------------------------- |
+| [eventEntry](#evententry) | SMALLINT | SIGNED     |     | NO   |         |        | Entry of the game event. Put negative entry to remove during event. |
+| [guid](#guid)             | INT      | UNSIGNED   | PRI | NO   |         | Unique |                                                                     |
 
 **Description of the fields**
 
 ### eventEntry
 
-Entry of the event (game\_event.eventEntry)
+Refers to: [game_event.entry](#game_event.entry).
 
-**Use**+\*eventEntry to have the gameobject added during the event
-**Use**-\*eventEntry to have it removed during the event
+Using a **positve** number will **add** the object to the event when is running.
+
+Using a **negative** number will **remove** the object to the event when is running.
 
 ### guid
 
-Guid of the gameobject participating in the event (gameobject.guid)
+Refers to: [gameobject.guid](#gameobject.guid).

--- a/docs/game_event_gameobject.md
+++ b/docs/game_event_gameobject.md
@@ -17,7 +17,7 @@ Contains all gameobjects instances that participate to any game event.
 
 ### eventEntry
 
-Refers to: [game_event.entry](#game_event.entry).
+Refers to: [game_event.entry](game_event#entry).
 
 Using a **positve** number will **add** the object to the event when is running.
 
@@ -25,4 +25,4 @@ Using a **negative** number will **remove** the object to the event when is runn
 
 ### guid
 
-Refers to: [gameobject.guid](#gameobject.guid).
+Refers to: [gameobject.guid](gameobject#guid).

--- a/docs/game_event_model_equip.md
+++ b/docs/game_event_model_equip.md
@@ -1,43 +1,38 @@
-# game\_event\_model\_equip
+# game_event_model_equip
 
 [<-Back-to:World](database-world)
 
-**The \`game\_event\_model\_equip\` table**
+**The \`game_event_model_equip\` table**
 
 Contains all creature instances that need to change display id and/or equipment during defined game events.
 
 **Table Structure**
 
-| Field             | Type      | Attributes | Key | Null | Default | Extra  | Comment                  |
-| ----------------- | --------- | ---------- | --- | ---- | ------- | ------ | ------------------------ |
-| [eventEntry][1]   | TINYINT   | SIGNED     |     | NO   | 0       |        | Entry of the game event. |
-| [guid][2]         | INT       | UNSIGNED   | PRI | NO   | 0       | Unique |                          |
-| [modelid][3]      | MEDIUMINT | UNSIGNED   |     | NO   | 0       |        |                          |
-| [equipment_id][4] | MEDIUMINT | UNSIGNED   |     | NO   | 0       |        |                          |
-
-[1]: #evententry
-[2]: #guid
-[3]: #modelid
-[4]: #equipment_id
+| Field                         | Type      | Attributes | Key | Null | Default | Extra  | Comment                  |
+| ----------------------------- | --------- | ---------- | --- | ---- | ------- | ------ | ------------------------ |
+| [eventEntry](#evententry)     | SMALLINT  | SIGNED     |     | NO   | 0       |        | Entry of the game event. |
+| [guid](#guid)                 | INT       | UNSIGNED   | PRI | NO   | 0       | Unique |                          |
+| [modelid](#modelid)           | MEDIUMINT | UNSIGNED   |     | NO   | 0       |        |                          |
+| [equipment_id](#equipment_id) | MEDIUMINT | UNSIGNED   |     | NO   | 0       |        |                          |
 
 **Description of the fields**
 
 ### eventEntry
 
-Entry of the event (game\_event.eventEntry)
+Refers to: [game_event.entry](game_event#entry).
 
--   In this table, event entry can only be positive
+Only a **positve** value can be used.
 
 ### guid
 
-Guid of the creature participating in the event (creature.guid)
+Refers to: [creature.guid](creature#guid).
 
 ### modelid
 
-New model to be used while the event is active (Refers to creature\_model\_info.modelid)
-Use 0 if only the [equipment](#game_event_model_equip-equipment_id) is to be changed during event.
+Refers to [creature_model_info.displayid](creature_model_info#displayid) to change the [creature](creature#guid)'s [model](creature_model_info#displayid) when the event running.
 
-### equipment\_id
+### equipment_id
 
-New equipment to be used during the event (Refers to creature\_equip\_template.entry))
-Use 0 if only the [model](#game_event_model_equip-modelid) is to be changed during event.
+Refers to [creature_equip_template.creatureid](creature_equip_template#creatureid) to change when the event running.
+
+If you don't want to add or change the current equipment being used, set the value to `0`, It will use [creature_equip_template](creature_equip_template#CreatureID) for the [creature_template](creature_template#entry) where it matches with [creature.id1](creature#id1) from [creature.guid](creature#guid).

--- a/docs/game_event_npc_vendor.md
+++ b/docs/game_event_npc_vendor.md
@@ -1,57 +1,51 @@
-# game\_event\_npc\_vendor
+# game_event_npc_vendor
 
 [<-Back-to:World](database-world)
 
-**The \`game\_event\_npc\_vendor\` table**
+**The \`game_event_npc_vendor\` table**
 
 This table allows you to change the items a vendor sells, or to create a [vendor list](npc_vendor) for an NPC who does not sell items unless an event is active.
 
 **Table Structure**
 
-| Field             | Type      | Attributes | Key | Null | Default | Extra | Comment |
-| ----------------- | --------- | ---------- | --- | ---- | ------- | ----- | ------- |
-| [eventEntry][1]   | TINYINT   | SIGNED     |     | NO   | 0       |       |         |
-| [guid][2]         | MEDIUMINT | UNSIGNED   | PRI | NO   | 0       |       |         |
-| [slot][3]         | SMALLINT  | SIGNED     |     | NO   | 0       |       |         |
-| [item][4]         | MEDIUMINT | UNSIGNED   | PRI | NO   | 0       |       |         |
-| [maxcount][5]     | MEDIUMINT | UNSIGNED   |     | NO   | 0       |       |         |
-| [incrtime][6]     | MEDIUMINT | UNSIGNED   |     | NO   | 0       |       |         |
-| [ExtendedCost][7] | MEDIUMINT | UNSIGNED   |     | NO   | 0       |       |         |
-
-[1]: #evententry
-[2]: #guid
-[3]: #slot
-[4]: #item
-[5]: #maxcount
-[6]: #incrtime
-[7]: #extendedcost
+| Field                         | Type      | Attributes | Key | Null | Default | Extra | Comment |
+| ----------------------------- | --------- | ---------- | --- | ---- | ------- | ----- | ------- |
+| [eventEntry](#evententry)     | SMALLINT  | SIGNED     |     | NO   | 0       |       |         |
+| [guid](#guid)                 | MEDIUMINT | UNSIGNED   | PRI | NO   | 0       |       |         |
+| [slot](#slot)                 | SMALLINT  | SIGNED     |     | NO   | 0       |       |         |
+| [item](#item)                 | MEDIUMINT | UNSIGNED   | PRI | NO   | 0       |       |         |
+| [maxcount](#maxcount)         | MEDIUMINT | UNSIGNED   |     | NO   | 0       |       |         |
+| [incrtime](#incrtime)         | MEDIUMINT | UNSIGNED   |     | NO   | 0       |       |         |
+| [ExtendedCost](#extendedcost) | MEDIUMINT | UNSIGNED   |     | NO   | 0       |       |         |
 
 **Description of the fields**
 
 ### eventEntry
 
-This is the eventEntry from the game\_event table that you wish to setup a vendor list for while the event is running.
+Refers to: [game_event.entry](game_event#entry).
+
+Only a **positve** value can be used.
 
 ### guid
 
-This is the guid of the NPC that you wish to create a vendor list for.
+Refers to: [creature.guid](creature#guid).
 
 ### slot
 
-Position of the item when the vendor window opens (order from top-left to bottom.right of the window with values 0 and then 1,2,3,etc).
+Refer to: [npc_vendor.slot](npc_vendor#slot).
 
 ### item
 
-This is an item from the item\_template table.
+Refers to: [item_template.entry](item_template#entry).
 
 ### maxcount
 
-The maximum number of copies of the item the vendor has available to be sold before [incrtime](#game_event_npc_vendor-incrtime) is up. If 0, then it is an unlimited number of copies.
+Refer to: [npc_vendor.maxcount](npc_vendor#maxcount).
 
 ### incrtime
 
-Combined with [maxcount](#game_event_npc_vendor-maxcount), this field tells how often (in seconds) the vendor list is refreshed and the limited item copies are restocked. For limited item copies, every refresh, the quantity is increased by item\_template.BuyCount
+Refer to: [npc_vendor.incrtime](npc_vendor#incrtime).
 
 ### ExtendedCost
 
-The value here corresponds to the ID in ItemExtendedCost.dbc and that ID controls the item's non monetary price, be it honor points, arena points, different types of badges or any combination of the above.
+Refer to: [npc_vendor.extendedcost](npc_vendor#extendedcost).

--- a/docs/game_event_pool.md
+++ b/docs/game_event_pool.md
@@ -1,30 +1,28 @@
-# game\_event\_pool
+# game_event_pool
 
 [<-Back-to:World](database-world)
 
-**The \`game\_event\_pool\` table**
+**The \`game_event_pool\` table**
 
 This table determines if a given pool is active for a given game event.
 
 **Table Structure**
 
-| Field           | Type      | Attributes | Key | Null | Default | Extra  | Comment                                                             |
-| --------------- | --------- | ---------- | --- | ---- | ------- | ------ | ------------------------------------------------------------------- |
-| [eventEntry][1] | TINYINT   | SIGNED     |     | NO   |         |        | Entry of the game event. Put negative entry to remove during event. |
-| [pool_entry][2] | MEDIUMINT | UNSIGNED   | PRI | NO   | 0       | Unique | Id of the pool                                                      |
-
-[1]: #evententry
-[2]: #pool_entry
+| Field                     | Type      | Attributes | Key | Null | Default | Extra  | Comment                                                             |
+| ------------------------- | --------- | ---------- | --- | ---- | ------- | ------ | ------------------------------------------------------------------- |
+| [eventEntry](#evententry) | SMALLINT  | SIGNED     |     | NO   |         |        | Entry of the game event. Put negative entry to remove during event. |
+| [pool_entry](#pool_entry) | MEDIUMINT | UNSIGNED   | PRI | NO   | 0       | Unique | Id of the pool                                                      |
 
 **Description of the fields**
 
 ### eventEntry
 
-This is the ID of the event.
+Refers to: [game_event.entry](game_event#entry).
 
--   +event adds the pool
--   -event removed the pool
+Using a **positve** number will **add** the pool to the event when is running.
 
-### pool\_entry
+Using a **negative** number will **remove** the pool to the event when is running.
 
-This is ID of the pool that you want either active or removed for the event.
+### pool_entry
+
+Refers to: [pool_pool.pool_id](pool_pool#pool_id).


### PR DESCRIPTION
From this PR: https://github.com/azerothcore/azerothcore-wotlk/pull/22309/files

Closes: Not yet opened

Updates:
- `game_event_creature`
- `game_event_gameobject`
- `game_event_model_equip`
- `game_event_npc_vendor`
and
- `game_event_pool`

Updates all the Table Strucute from `TINYINT` to `SMALLINT` and while at it attempt to bring them to wiki standards.

For `game_event_pool` I'm not sure if it refers to `pool_pool.pool_id` or `pool_template.entry`
