### PR TITLE
Update how-to-restart-and-debug.md

### DIFF
--- a/docs/how-to-restart-and-debug.md
+++ b/docs/how-to-restart-and-debug.md
@@ -10,84 +10,43 @@ The worldserver instead handles all connections related to the game mechanics an
 
 Authserver and worldservers can be placed on different environments. However, in the following guide we will explain how to run them together on the same environment.
 
-## How to start the services
+## The `startup-scripts` Engine
 
-Both authserver and worldserver can be started by simply running the compiled binaries after [completing the installation](Installation).
+We have introduced a new set of startup scripts that provide a powerful and unified way to run, manage, and debug your servers. This is now the recommended way to handle the `authserver` and `worldserver` processes for all non-Docker installations.
 
-## How to configure a restarter
+These scripts offer advanced features like automatic restarts via systemd or PM2, session management (using `tmux` or `screen`), and integrated GDB debugging for crash analysis.
 
-Restarting and debugging an application works in many different ways depending on your operating system. That is why we always suggest to use our Docker solution that is fully supported on all platforms.
+For a complete guide on how to use and configure the new startup scripts, please refer to the official **[README.md located in the startup-scripts directory](https://github.com/azerothcore/azerothcore-wotlk/blob/master/apps/startup-scripts/README.md)**.
 
-However, if you need to keep your server up and running after a crash and checking what is going on with your code, you can do it using a restarter and a debugger.
+### Basic Usage
 
-Below is an explanation on how to use our integrated restarter scripts and the [GDB](https://www.gnu.org/software/gdb/) (GNU Project Debugger) utility as well to generate crash-dumps.
+The easiest way to use the new system is through the acore.sh dashboard:
 
-### Restarter using acore dashboard (only for bash)
+```bash
+# To run the worldserver with the new engine
+./acore.sh run-worldserver
 
-You can use `./acore.sh run-worldserver` and `./acore.sh run-authserver`.
-
-They both work out of the box when you compile with the dashboard.
-
-{% include note.html content="To enable GDB, you can use <b>AC_RESTARTER_WITHGDB=true</b> as an environment variable or by adding it to your <b>/conf/config.sh</b> file.</br>
-If the server crashes after enabling GDB, you will find the crashdump file (gdb.txt) within the /env/ folder. <b>Keep in mind that you should compile your code with one of the following compilation types: Debug or RelWithDebInfo, otherwise GDB will not work properly</b>" %}
-
-### Using Docker (cross-platform)
-
-Our Docker system integrates the scripts above within the docker-compose. It means that enabling GDB works exactly in the same way in Docker too.
-Moreover our docker-compose uses the [restart-policy feature](https://docs.docker.com/config/containers/start-containers-automatically/) to keep the containers up and running.
-
-For more information, please refer to the [Install-with-Docker](install-with-docker) documentation. 
-You will also find a guide on how to debug your code by using VSCode combined with its Remote Docker extension.
-
-### Advanced restarter (only for bash)
-
-For more advanced restarters that include several other useful configurations, you can try our "run-engine" system written in bash.
-
-Here you can find the restarters for linux/bash environments: https://github.com/azerothcore/azerothcore-wotlk/tree/master/apps/startup-scripts
-
-Those scripts are automatically copied after the compilation to the `/dist` directory if you're using our `./acore.sh` dashboard
-
-You can copy the `conf.sh.dist` and create a `conf-world.sh` file to customize those documented configurations (do the same for the `conf-auth.sh`). This way you will have both the restarter and GDB pre-configured to create a `gdb.txt` (crashdump) file when the core crashes. Make sure to use `Debug` or `RelWithDebInfo` compilation (in your CMake command) in order to get meaningful crash reports.
-
-Then copy the `restarter-world.sh` and the `restarter-auth.sh` from the "examples" beside your conf file and in the same folder of the "run-engine" file.
-
-Eventually you will have something like this:
-
-[![example][1]][1]
-
-Run those two restarter scripts to have both authserver and worldserver restarters with GDB support.
-
-
-### Manual way (crossplatform)
-
-Always make sure to use **Debug** or **RelWithDebInfo** compilation (in your CMake command) in order to get meaningful crash reports.
-
-Create a file called `gdb.conf` with this inside:
-
-    set logging on
-    set debug timestamp
-    run -c ../etc/worldserver.conf
-    bt
-    bt full
-    info thread
-    thread apply all backtrace full
-
-To debug or create a crashdump, you can then use the GDB command as described in its documentation:
-
-```
-gdb -x gdb.conf --batch ./worldserver
+# To run the authserver with the new engine
+./acore.sh run-authserver
 ```
 
-This command should be enough to both attach your IDE to debug your code and also generate a crashdump when the server crashes.
+### Configuration and Debugging
 
-For a more advanced and "universal" restarter, personally I'm using [PM2][2].
+To enable the GNU Debugger (GDB) and generate crash reports, you need to edit the configuration file for your service. For example, for a service named `ac-world-1`, you would edit a file similar to ac-world-1-run-engine.conf and set `GDB_ENABLED=1`.
 
+```properties
+// ...existing code...
+# Enable/disable GDB execution
+export GDB_ENABLED=1
+// ...existing code...
 ```
-pm2 start "gdb -x gdb.conf --batch ./worldserver"
-```
 
-It should be enough to automatically restart, monitor, and utilize GDB with your server.
+If the server crashes after enabling GDB, you will find the crashdump file (e.g., `gdb-YYYY-MM-DD-HH-MM-SS.txt`) inside the `apps/startup-scripts/logs/crashes/` directory. <b>Keep in mind that you must compile your code with one of the following compilation types: `Debug` or `RelWithDebInfo`, otherwise GDB will not produce meaningful reports.</b>
 
+## Using Docker (cross-platform)
 
-  [1]: assets/images/how-to-restart-and-debug/vscode-files-explorer.png
-  [2]: https://pm2.keymetrics.io/
+Our Docker setup integrates the `startup-scripts` engine. This means that enabling GDB and managing restarts works seamlessly within the Docker environment as well. Moreover, our docker-compose.yml uses the [restart-policy feature](https://docs.docker.com/config/containers/start-containers-automatically/) to automatically keep the containers up and running after a crash or a system reboot.
+
+For more information, please refer to the [Install with Docker](https://www.azerothcore.org/wiki/Install-with-Docker) documentation. You will also find a guide on how to debug your code by using VSCode combined with its Remote Docker extension.
+
+Similar code found with 1 license type


### PR DESCRIPTION
This pull request updates the documentation in `docs/how-to-restart-and-debug.md` to introduce a new unified startup system for managing servers, replacing the previous restarter scripts. It simplifies server management and debugging, integrates advanced features, and enhances cross-platform support, especially for Docker environments.

### Introduction of the `startup-scripts` Engine:
* Replaced the old restarter scripts with the new `startup-scripts` engine, offering features like automatic restarts (via `systemd` or `PM2`), session management (`tmux` or `screen`), and integrated GDB debugging for crash analysis.
* Added instructions for using the new `acore.sh` dashboard commands (`./acore.sh run-worldserver` and `./acore.sh run-authserver`) to simplify server startup.

### Enhanced Debugging and Crash Reporting:
* Updated the configuration process to enable GDB for crash analysis, including generating crash reports in a dedicated directory (`apps/startup-scripts/logs/crashes/`).

### Improved Docker Integration:
* Integrated the `startup-scripts` engine with Docker, ensuring seamless debugging and automatic restarts using Docker's restart-policy feature. Provided links to Docker documentation and guides for debugging with VSCode.
