### PR TITLE
Update / Modernise few instalation related pages.

### DIFF
--- a/docs/database-installation.md
+++ b/docs/database-installation.md
@@ -26,7 +26,7 @@ Now you will either drag/run or copy-paste the content of the file [create_mysql
 
 {% include important.html content="The file above file is a Query or SQL file, is not a SQL script, for the case of DBeaver users that may get that confusion." %}
 
-{% include tip.html content="You can change the password of the user you are creating for increased security, either in the query file, execution or after in your Database client of choice." %}
+{% include tip.html content="You can change the password of the user you are creating, and you should for increased security, refering to the `acore` user, you can do this either in the query file, execution or after in your Database client of choice." %}
 
 ## Populating the database
 

--- a/docs/database-installation.md
+++ b/docs/database-installation.md
@@ -7,36 +7,50 @@
 
 ## Creating the Database in MySQL
 
-### Creating the Databases and User
+You will download or copy the contents of [create_mysql.sql](https://github.com/azerothcore/azerothcore-wotlk/blob/master/data/sql/create/create_mysql.sql).
 
-First of all, you need to create the acore user. You need to run the script below within a MySQL client or with the MySQL command-line interface (CLI). 
-You need to run the script as the **root** user of MySQL within a MySQL client or the MySQL cli.
+Using the created super-user (by default is `root`) you will open any of database client refered in the requirements page (HeidiSQL, MySQL command-line interface [CLI], etc... or others your choice).
 
-https://github.com/azerothcore/azerothcore-wotlk/blob/master/data/sql/create/create_mysql.sql
+Now you will either drag/run or copy-paste the content of the file [create_mysql.sql](https://github.com/azerothcore/azerothcore-wotlk/blob/master/data/sql/create/create_mysql.sql).
 
-{% include important.html content="Use the MySQL root user ONLY to run the script above, never run the core as root or administrator!" %}
+### HeidiSQL (most popular for newer users of MySQL).
+- Into your `Query` tab and press the blue "play" button or pressing `F9` (by default) to run the query.
 
-{% include tip.html content="You can change the password of the user you are creating for increased security." %}
+
+### MySQL CLI (most popular for linux users.)
+- In your terminal of choice (example given for `CMD` of Windows, which is recommended to be ran as `Administrator`) 
+`mysql -u YourSuperUsername -h 127.0.0.1 -p < "YourPath/create_mysql.sql"` 
+
+(This will prompt your password after being executed, in the safe side make sure the path is between "" and using / in the case is giving you `Access is denied` or `The system cannont find the file specified` check your path and file.extension in the case you do have the permissions or that you've executed as `Administrator`)
+
+
+{% include important.html content="The file above file is a Query or SQL file, is not a SQL script, for the case of DBeaver users that may get that confusion." %}
+
+{% include tip.html content="You can change the password of the user you are creating for increased security, either in the query file, execution or after in your Database client of choice." %}
 
 ## Populating the database
 
-If you want to know how the SQL directory works or plan to have custom changes we recommend you read [this](sql-directory).
+### Automatic Database Updater (Recommended, specially for newer users.)
 
-#### Automatic Database Updater
+The `authserver` and `worldserver` checks and applies all needed database files at startup.
 
-The Auth- and Worldserver checks and applies all needed database files at startup.
+To edit the automatic database updater you can find it in `authserver.conf` and `worldserver.conf` under **AUTOUPDATER** OR **UPDATE SETTINGS**.
 
-To edit the automatic database updater you will find the necessary settings in authserver.conf and worldserver.conf under **UPDATE SETTINGS**.
+1. Start `authserver`, in the `Build` folder you created, under `\bin\RelWithDebInfo` (for Windows) or `env/dist/bin` (for Linux).
+2. Start `worldserver` in the same location.
 
-1. Start Authserver.exe, in the Build folder you created, under \bin\RelWithDebInfo or \bin\Debug folder.
-2. Start Worldserver.exe, in the same location.
+If you get the following message in your console press ENTER to create and populate the databases (for: `acore_auth`, `acore_characters` or `acore_world`).
 
-If you get the following message in your console press enter to create and populate the databases.
-
+Example:
 ```
 Database "acore_auth" does not exist
 Do you want to create it? [yes (default) / no]:
 ```
+
+If you want to know how the SQL directory works or plan to have custom changes we recommend you read [this](sql-directory), for manual or automatic execution.
+
+{% include tip.html content="If you wish ever to start any of the databases from scratch, you always drop their databases and let them re-create and re-populate, keep in mind if you drop a database you WILL LOOSE everything in it, highly recommend if you have any custom changes SQL or Modules changes, backup your database before executing the queries and/or adding the modules, any SQL changes you should save the queries outside of the database in the case you wish to use them again in the future." %}
+
 
 <br>
 

--- a/docs/database-installation.md
+++ b/docs/database-installation.md
@@ -28,6 +28,19 @@ Now you will either drag/run or copy-paste the content of the file [create_mysql
 
 {% include tip.html content="You can change the password of the user you are creating, and you should for increased security, refering to the acore user, you can do this either in the query file, execution or after in your Database client of choice." %}
 
+In the case you want you to use different information to connected to their respective database related to your `authserver` and `wolrdserver`.
+
+They follow this structure:
+`Variablename = "MySQLIP;Port;Username;Password;database"`
+The values below are the default, but you're free to change them, if you need or want, we don't recommend if you dont know what you're doing.
+
+```
+LoginDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_auth" worldserver.conf / authserver.conf
+WorldDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_world" worldserver.conf
+CharacterDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_characters" worldserver.conf
+```
+
+
 ## Populating the database
 
 ### Automatic Database Updater (Recommended, specially for newer users.)

--- a/docs/database-installation.md
+++ b/docs/database-installation.md
@@ -26,7 +26,7 @@ Now you will either drag/run or copy-paste the content of the file [create_mysql
 
 {% include important.html content="The file above file is a Query or SQL file, is not a SQL script, for the case of DBeaver users that may get that confusion." %}
 
-{% include tip.html content="You can change the password of the user you are creating, and you should for increased security, refering to the `acore` user, you can do this either in the query file, execution or after in your Database client of choice." %}
+{% include tip.html content="You can change the password of the user you are creating, and you should for increased security, refering to the acore user, you can do this either in the query file, execution or after in your Database client of choice." %}
 
 ## Populating the database
 

--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -38,10 +38,17 @@ If you want to see the `GM Commands` in your server, you can check your `acore_w
 
 You also may also refer to the wiki [GM Commands](gm-commands).
 
+Highely recommend also if you want to have a similiar expeirence of wowhead [wowgaming](https://wowgaming.github.io/) provides us with an similiar but focused on Azerothcore, wowgaming's [aowow](https://wowgaming.altervista.org/aowow/) version.
+
+This similiar version of wowhead, doesn't update with your changes, they use their own `Data` they provided previously in the server setup steps and they keep their website updated every week based on azerothcore's updates to the core.
+
 
 ## Setting up Remote Access
 For development purposes, this step is not necessary. However, for increased security when you want other people to make accounts you should set up a registration form, so you don't have to paste their passwords. Check out [Remote Access](remote-access) on how to send commands into the server.
 
+Also refer to [account](account) which provides some `php` examples how do Calculate, Get and Verify `SRP6` protocol, in the addition of trying to make a way to create or access account information related to Azerothcore.
+
+In addition to it we provide a [catologue](https://www.azerothcore.org/catalogue.html) mainly focused in modules created by the community, but you may find others like a Registration page.
 
 ## Help
 

--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -7,32 +7,41 @@
 
 ## Starting the server
 
-- Run authserver and worldserver in your build folder.
+1. Start `authserver`, in the `Build` folder you created, under `\bin\RelWithDebInfo` (for Windows) or `env/dist/bin` (for Linux).
+2. Start `worldserver` in the same location.
 
-For detailed information on how to configure a restarter and a debugger go to [how-to-restart-and-debug](how-to-restart-and-debug) page
+For detailed information on how to configure a restarter and a debugger go to [how-to-restart-and-debug](how-to-restart-and-debug) page (For linux environments).
 
-{% include warning.html content="NEVER create an account directly into your database unless you are ABSOLUTELY SURE that you know what to do and how to do it!" %}
-
-- Next, create your Login Account by typing directly into the **worldserver** window the GM Command **account create**. Syntax: (see examples below)
-
-- If you wish to set the account as a GM then type into the worldserver window: **account set gmlevel $account #level #realmid** where **$account** is the account name to change, **#level** can be 0-4 and **#realmid** is the realm ID. Setting a **#level** of "3" is GM account level (higher numbers = more access), and the "-1" is the realm ID that stands for "all realms".
-
-{% include tip.html content="Open your <b>acore_world</b> database and find the <b>command</b> table. This shows a full list of GM Commands, descriptions, and security levels.<br/>This will always be the most up-to-date list you can find, assuming you keep your DB and Core updated." %}
-
-- Minimize your servers and run **WoW** (never run WoW using the Launcher unless you edited the realmlist.wtf's patchlist option above).
-
-- Log in using the user/pass you just created.
-
-- The AzerothCore realm should be selectable. Log in, create a character, and you're all done!
 
 ## Creating an Account
 
 Read [creating accounts](creating-accounts).
 
+{% include warning.html content="NEVER create an account directly into your database unless you are ABSOLUTELY SURE that you know what to do and how to do it!" %}
+
+- Inside of the World of Warcraft Folder (`3.3.5` not `3.4.x` "modern" version), you will see a `Data` folder and a locale folder inside of `Data` example `enUS` or `enGB`, inside of that folder **should exist** a `realmlist.wtf` (in the case it doesn't exist, create it).
+
+{% include tip.html content="In the case you created realmlist.wtf file and doesn't work, make sure you've -Hide extensions for known file types- unchecked in your windows folder options." %}
+
+- Open `realmlist.wtf` and `set realmlist 127.0.0.1` (or you can change the IP or use a DNS).
+
+- Open your `wow.exe` not any launcher of any sort.
+
+- Login into your account by using your `username` and `password` the e-mail functionality doesn't work (as a login into client) for AzerothCore.
+
+- The AzerothCore realm should be selectable. Log in, create a character, and you're all done!
+
+{% include tip.html content="In the case you're connecting to the server in the same machine as the client, and the realm gets stuck (as you can't do anything after logging in) trying pressing ENTER in the worldserver.exe (this for windows issue), we recommend disabling Windows Terminal -QuickEdit Mode- which tends to hang the CLI applications for Windows 10 and foward." %}
+
+
+If you want to see the `GM Commands` in your server, you can check your `acore_world` database and find the `command` table. This shows a full list of GM Commands, descriptions, and security levels.<br/>This will always be the most up-to-date list you can find, assuming you keep your DB and Core updated.
+
+You also may also refer to the wiki [GM Commands](gm-commands).
+
+
 ## Setting up Remote Access
 For development purposes, this step is not necessary. However, for increased security when you want other people to make accounts you should set up a registration form, so you don't have to paste their passwords. Check out [Remote Access](remote-access) on how to send commands into the server.
 
-<br>
 
 ## Help
 

--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -27,7 +27,7 @@ Read [creating accounts](creating-accounts).
 
 - Open your `wow.exe` not any launcher of any sort.
 
-- Login into your account by using your `username` and `password` the e-mail functionality doesn't work (as a login into client) for AzerothCore.
+- Log in using the user/pass you just created.
 
 - The AzerothCore realm should be selectable. Log in, create a character, and you're all done!
 

--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -46,6 +46,8 @@ This similiar version of wowhead, doesn't update with your changes, they use the
 ## Setting up Remote Access
 For development purposes, this step is not necessary. However, for increased security when you want other people to make accounts you should set up a registration form, so you don't have to paste their passwords. Check out [Remote Access](remote-access) on how to send commands into the server.
 
+## Example of a local Registration without the Terminal
+
 Also refer to [account](account) which provides some `php` examples how do Calculate, Get and Verify `SRP6` protocol, in the addition of trying to make a way to create or access account information related to Azerothcore.
 
 In addition to it we provide a [catologue](https://www.azerothcore.org/catalogue.html) mainly focused in modules created by the community, but you may find others like a Registration page.

--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -27,7 +27,7 @@ Read [creating accounts](creating-accounts).
 
 - Open your `wow.exe` not any launcher of any sort.
 
-- Log in using the user/pass you just created.
+- Log in using the `username` and `password` you just created.
 
 - The AzerothCore realm should be selectable. Log in, create a character, and you're all done!
 

--- a/docs/final-server-steps.md
+++ b/docs/final-server-steps.md
@@ -27,6 +27,8 @@ Read [creating accounts](creating-accounts).
 
 - Open your `wow.exe` not any launcher of any sort.
 
+{% include warning.html content="DO NOT USE YOUR E-MAIL TO LOGIN, IT DOES NOT WORK, USE THE USERNAME" %}
+
 - Log in using the `username` and `password` you just created.
 
 - The AzerothCore realm should be selectable. Log in, create a character, and you're all done!

--- a/docs/installing-a-module.md
+++ b/docs/installing-a-module.md
@@ -5,14 +5,22 @@
 | This article is a part of the Installation Guide. You can read it alone or click the previous link to easily move between the steps. |
 | [<< Step 8: Client Setup](client-setup)                                                                                              |
 
-Adding a module is an optional step to alter the blizzlike gameplay offered by AzerothCore by default.
+AzerothCore offers a modular setup, which allows you to alter your experience in your needs, being by your own creation or others.
+
+The advantange about this modular setup? Allows you to do changes to your core without actually changing the base core, which is one of many issues with "changes" to the core in other emulators, which may require you to it's own branch or even fork to operate.
+
+Note that in cases that the core needs to be modified to suit a module, this is the same as it would be for other emulators, but this isn't the most commun example for AzerothCore, is the exception.
 
 ## Installing the Module
 
-1. Find a module of your needs in the [AzerothCore Catalogue](https://www.azerothcore.org/catalogue#/).
-2. Clone the repository
-    - Clone the repository using Git the same way AzerothCore was first cloned in the [Core Installation](core-installation). The repository should be cloned into the \modules\ directory. i.e E:\AzerothCore\modules\
-    - Download the ZIP file from the catalog and extract it in the \modules\ directory. i.e E:\AzerothCore\modules\mod-anticheat
+1. To find and choose a module you wish to use you can use [AzerothCore Catalogue](https://www.azerothcore.org/catalogue#/) or in [GitHub](https://github.com/search?q=&type=repositories) search function for AzerothCore or the [respective tags](https://www.azerothcore.org/catalogue#/how-to).
+
+Be sure to read the instructions or readme files that come with the module.
+
+2. Clone or download from the repository.
+    - If you clone using Git, it would be the same as you did for [Core Installation](core-installation), but into your module's folder as example: `C:\azerothcore-wotlk\modules`
+
+    - If you decide to manually download, for the case of Github, you click on the green button `<> Code` and `Download ZIP`, when you do this way, you will not be able to easily update it without maunully doing this everytime it has an update, you extract the contents into your module's folder as example: `C:\azerothcore-wotlk\modules`
 
 {% include note.html content="If your module has a suffix i.e. -master. This needs to be removed in order for the module to work!" %}
 
@@ -21,22 +29,40 @@ Adding a module is an optional step to alter the blizzlike gameplay offered by A
 In order for your module to work you need to recompile the source. For an in-depth guide on how to recompile, read over [Core Installation](core-installation) again.
 
 1. Reconfigure and regenerate CMake.
+
     - To make sure the module was correctly installed you can check if it can be found in the CMake logs under **\* Modules configuration (static)**
 
 2. Rebuild the core.
 
-Your Worldserver will automatically run any SQL Queries provided by the Modules.
+    - If you face errors here can be many things, can 
+    - If you get `error LINK2019: unresolved external symbol "void __cdcel Addmod_module_masterScripts(void)` you missed removing the branch name in the suffix e.g `-master` from the module folder.
+    - The module is not up to date (core has changes that module hasn't updated to).
+    - Your core is not up to date (the module has been updated but your current core hasn't).
+    - You missed an insturction from the module.
 
-You should always check the README file of the module to see if any manual steps are needed for the module to function properly.
+3. Copying and renaming the module configuration files
 
-## Common Errors
+Similiar how is done in [Server Setup](server-setup) phase, example below is for windows.
 
-- During compiling I get the error "error LINK2019: unresolved external symbol "void __cdcel Addmod_module_masterScripts(void)"
-    - Remove **-master** from the modules directory name.
+You will need to go in the `Build` folder you created, under `\bin\RelWithDebInfo\configs\modules` and make a copy and rename the copy to the following:
+`ModuleName.conf.dist - Copy` to `ModuleName.conf`
 
-- The module is for some reason not working in-game.
-    - You can always use the **.server debug** command to see all loaded modules.
-    - Always fall back to the README file from the module for the exact installation steps for that module.
+And any changes you want to do the module (if any), you know change `ModuleName.conf` not the `ModuleName.conf.dist`.
+
+4. SQL Requirements
+
+    - If the module you're using has the same strucuture for example: `data\sql\db-DatabaseName` as [skeleton-module](https://github.com/azerothcore/skeleton-module/tree/master/data) it should apply automatically any SQL upon running `worldserver`.
+
+    - In the case the module doesn't follow that strucuture for example `data\sql\world` you will have to run those queries manually into their respectives databases.
+
+After that, if you still having issues with the module, running `.server debug` and it can display how many modules are in the server (doesn't mean they are active or running, only that they were enabled in CMake and were compiled.)
+
+```
+List of enabled modules:
+|- mod-1v1-arena
+```
+
+If the module appears up there, check the config file of the module, the place where you renamed previously `ModuleName.conf.dist - Copy` to `ModuleName.conf` some modules come "disabled" by default.
 
 <br>
 

--- a/docs/linux-server-setup.md
+++ b/docs/linux-server-setup.md
@@ -20,7 +20,7 @@ Some files are optional but highly recommended:
 | maps      | Mandatory          |
 | vmaps     | HIGHLY RECOMMENDED |
 | mmaps     | HIGHLY RECOMMENDED |
-| cameras   | Recommended        |
+| Cameras   | Recommended        |
 
 ## Option 1: Download Pre-Extracted Files
 
@@ -57,6 +57,7 @@ mmaps_generator
 vmap4_assembler
 vmap4_extractor
 ```
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$AC_CODE_DIR/src/tools/mmaps_generator`.
 
 2. Browse into **$AC_CODE_DIR/apps/extractor/** and copy "**extractor.sh**" into your World of Warcraft folder with the previous files.
 

--- a/docs/linux-server-setup.md
+++ b/docs/linux-server-setup.md
@@ -57,7 +57,7 @@ mmaps_generator
 vmap4_assembler
 vmap4_extractor
 ```
-Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$AC_CODE_DIR/src/tools/mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, in the case it's not present automatically, you can find the YAML file in `$AC_CODE_DIR/src/tools/mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
 
 2. Browse into **$AC_CODE_DIR/apps/extractor/** and copy "**extractor.sh**" into your World of Warcraft folder with the previous files.
 

--- a/docs/linux-server-setup.md
+++ b/docs/linux-server-setup.md
@@ -57,7 +57,7 @@ mmaps_generator
 vmap4_assembler
 vmap4_extractor
 ```
-Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$AC_CODE_DIR/src/tools/mmaps_generator`.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$AC_CODE_DIR/src/tools/mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
 
 2. Browse into **$AC_CODE_DIR/apps/extractor/** and copy "**extractor.sh**" into your World of Warcraft folder with the previous files.
 

--- a/docs/macos-server-setup.md
+++ b/docs/macos-server-setup.md
@@ -48,7 +48,7 @@ vmap4_assembler
 vmap4_extractor
 ```
 
-Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$HOME/Azerothcore/src/tools/mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, in the case it's not present automatically, you can find the YAML file in `$HOME/Azerothcore/src/tools/mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
 
 
 **DBC and Maps files**

--- a/docs/macos-server-setup.md
+++ b/docs/macos-server-setup.md
@@ -48,7 +48,7 @@ vmap4_assembler
 vmap4_extractor
 ```
 
-Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$HOME/Azerothcore/src/tools/mmaps_generator`.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$HOME/Azerothcore/src/tools/mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
 
 
 **DBC and Maps files**

--- a/docs/macos-server-setup.md
+++ b/docs/macos-server-setup.md
@@ -20,7 +20,7 @@ Some files are optional but highly recommended:
 | maps      | Mandatory          |
 | vmaps     | HIGHLY RECOMMENDED |
 | mmaps     | HIGHLY RECOMMENDED |
-| cameras   | Recommended        |
+| Cameras   | Recommended        |
 
 ## Option 1: Download Pre-Extracted Files
 
@@ -40,12 +40,16 @@ If you intend to use an enUS client you can download the data files below. If yo
 
 **(Not needed if you downloaded the files above)**
 
-Go to your AzerothCore build directory (e.g. $HOME/azeroth-server/bin/) and copy the following files to your World of Warcraft binaries directory.
+1. Browse into your install directory (e.g. **$HOME/azeroth-server/bin/**) and copy the following files into your World of Warcraft folder (where the Wow.exe is located).
+```
+map_extractor
+mmaps_generator
+vmap4_assembler
+vmap4_extractor
+```
 
-* **mapextractor**
-* **mmaps_generator**
-* **vmap4assembler**
-* **vmap4extractor**
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator`, you can find the YAML file in `$HOME/Azerothcore/src/tools/mmaps_generator`.
+
 
 **DBC and Maps files**
 

--- a/docs/mmaps-config.md
+++ b/docs/mmaps-config.md
@@ -1,0 +1,138 @@
+# MMap Configuration File
+
+## skipLiquid
+Usage: `true` or `false`
+
+Default: `false`
+
+This is what responsible for creature or player's without control movement in liquids, water, lava or liquid areas.
+
+
+## skipContinents
+Usage: `true` or `false`
+
+Default: `false`
+
+This is what responsible for creature or player's without control movement for the open-world, which excludes instances like Dungeons, Raids or specific un-used or test maps which are not considered "junk" maps.
+
+
+## skipJunkMaps
+Usage: `true` or `false`
+
+Default: `true`
+
+This is what responsible for creature or player's without control movement for what the core and extractors refer as "junk" maps which are files that do not contain full data to be considered a proper map.
+
+
+## skipBattlegrounds
+Usage: `true` or `false`
+
+Default: `false`
+
+This is what responsible for creature or player's without control movement for Battkegrounds Instances.
+
+
+## dataDir
+Usage: Directory / Path
+
+Default: `./`
+
+Path to the directory containing navigation data files. This directory should contain the "maps" and "vmaps" folders, and is also where the "mmaps" folder will be created or located.
+
+
+### walkableSlopeAngle
+Usage: Integer / whole  Number in degrees
+
+Default: `60`
+
+Maximum slope angle (in degrees) NPCs can walk on. Surfaces steeper than this will be considered unwalkable.
+
+**TECHNICAL PART [Cell Size Calculation] Can be skipped for normal users** 
+
+Many parameters below are defined in "cell units". In RecastDemo, you often work with world units instead of cell units. By default, these cell units are converted to world units using the formula:
+
+```
+cellSize = MMAP::GRID_SIZE / (verticesPerMapEdge - 1)
+```
+
+**WHERE:**
+
+```
+MMAP::GRID_SIZE = 533.3333f (the size of one map tile in world units)
+verticesPerMapEdge = number of vertices along one edge of the full map grid
+```
+
+**EXAMPLE:**
+
+```   
+If verticesPerMapEdge = 2000, then: cellSize ≈ 533.3333 / (2000 - 1) ≈ 0.2667 world units per cell
+
+To convert a value from cell units to world units (e.g., walkableClimb), multiply by cellSize. For example, a walkableClimb of 6 corresponds to: 6 * 0.2667 ≈ 1.6 world units
+
+```
+
+
+### walkableHeight
+Usage: Integer / whole  Number
+
+Default: `6`
+
+Minimum ceiling height (in cell units) NPCs need to pass under an obstacle. Controls how much vertical clearance is required. To convert to world units, multiply by cellSize (see "Cell Size Calculation").
+
+
+### walkableClimb
+Usage: Integer / whole  Number
+
+Default: `6`
+
+
+
+### walkableRadius
+Usage: Integer / whole  Number
+
+Default: `2`
+
+
+
+### verticesPerMapEdge
+Usage: Integer / whole  Number
+
+Default: `2000`
+
+
+
+### verticesPerTileEdge
+Usage: Integer / whole  Number
+
+Default: `80`
+
+
+
+### maxSimplificationError
+Usage: Float / Number with decimal values
+
+Default: `1.8`
+
+
+
+### mapsOverrides
+Usage: [MapID](map)
+
+Default:
+```
+562 | Blade's Edge Arena
+walkableRadius: 0
+This allows walking on the ropes to the pillars
+
+48 | Blackfathom Deeps
+cellSizeVertical: 0.5334 # ch*2 = 0.2667 * 2 ≈ 0.5334. 
+Reduce the chance to have underground levels.
+
+529 | Arathi Basin
+tilesOverrides: 30,29: 
+walkableSlopeAngle: 45
+Make sure that Fear will not drop players rom cliff in Lumber Mill
+https://github.com/azerothcore/azerothcore-wotlk/pull/22462#issuecomment-3067024680
+```
+
+### debugOutput

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -7,45 +7,77 @@
 
 This guide is intended for advanced setups or just to provide more details in setting up your realm for local or internet use. In general, the default setup explained in your particular OS-specific guide should be fine for simple setups.
 
-## Worldserver and Authserver configurations
+## Authserver and Worldserver configurations
 
-For almost all basic setup scenarios the default localhost (127.0.0.1) IP settings should be left alone. The default bindip (0.0.0.0) should be left alone as well.
+For the majority of the cases the default configuration values for `LoginDatabaseInfo`, `CharacterDatabaseInfo` and `WorldDatabaseInfo` should be left alone as `127.0.0.1` (also known as `localhost`, the current machine hosting/running the `authserver` and `worldserver`), the same goes for `BindIP` should be left alone as well as `0.0.0.0`.
 
-### Setting the auth database realmlist for internet connections
+If you need to connect to your database from one external machine, read [this](https://www.enovision.net/mysql-ssh-tunnel-heidisql) instead open ports to the MySQL server.
 
-This is where you have to use your internet IP so clients from the internet can find your server. You have to have the ports 3724 (authserver) and 8085 (worldserver) forwarded or open from your router/firewall. Using TCP protocol.
+### Port Forwarding (Incoming / Inbound)
 
-**Realmlist Table**
+| DST Port | Protocol | Destination | Comment     |
+| -------- | -------- | ----------- | ----------- |
+| 3724     | TCP      | any         | authserver  |
+| 8085     | TCP      | any         | worldserver |
 
-You need to make sure that your **authserver** application directs incoming connections to your realm.
+This are the ports used by the `authserver` and `worldserver` which you will be required to port foward / open the ports in your router and/or firewall to allow external connections to your server.
 
-- Run your chosen database management tool (ex. SQLYog or HeidiSQL) or with the MySQL command-line interface (CLI).
+How to [port foward](https://portforward.com), this is for majority of routers, not all.
 
-- If you need to connect to your database from one external machine, read https://www.enovision.net/mysql-ssh-tunnel-heidisql instead open ports to the MySQL server.
+You need to make sure that your **authserver** application directs incoming connections to your server, normally is windows issue under the `UAC` (User Account Control), which will prompt after being executed once, normally.
 
-- Open the **acore_auth** database and find the **realmlist** table. You need to edit the **address field** according to your needs:
+{% include warning.html content="NEVER open your MYSQL Ports (normally 8085) unless you are ABSOLUTELY SURE that you know what to do, no one but the machine hosting the service should have access to it." %}
 
-    - LAN IP (192.168.x.x) - If you are installing AzerothCore on a different computer from where you run WoW, but all the computers involved are on the same network (router) use that computer's Local Area Network IP.
 
-    - 127.0.0.1 - Also known as "localhost". Leave this setting alone here and in your configs, if you've installed AzerothCore on the same computer you run WoW on, and only you are connecting to it.
+### Realmlist
 
-    - Public IP address – If you want other people to connect to your server, use your external IP. Visit http://www.whatismyip.com/ to find your external IP address. 
-        -  If you're hosting it from a home network you'll likely need to set up the proper port forwards, which isn't covered within the scope of this guide. https://portforward.com has guides for most routers, and your Internet Service Provider should be able to assist with this. 
-    
-    - Fully qualified domain name - (mydomain.com or warcraft.mydomain.com) Similar to an external IP address, this would be used if you want other people to connect to your server with the added benefit of not needing to track a potentially dynamic IP address. 
-        - Similar to the Public IP address, it's likely that you'll need to set up port forwards if you're hosting from a home network.
-        - Additionally, you'll need to configure DNS to point to the server's public IP address. Setting up DNS is out of the scope of this guide, though your domain registrar or dynamic DNS provider should have this documentation available.
+Open the `acore_auth` database and find the `realmlist` table. 
 
-{% include note.html content="If you are using HeidiSQL, make sure you are in the Data tab when you edit values." %}
+`acore_auth.realmlist`
+| id | name | address | localAddress | localSubnetMask | port |
+| ---: | --- | --- | --- | --- | ---: |
+| 1 | AzerothCore | 127.0.0.1| 127.0.0.1| 255.255.255.0 | 8085 |
 
- - MySQL CLI Commands (This step is not needed if you used a MySQL Manager like HeidiSQL)
-    - `$ sudo mysql`
-    - You should see a prompt change to mysql>
-    - `use acore_auth`;
-    - **Replace your IP with the one you've chosen to use from above**
-    - `UPDATE realmlist SET address = '[your_ip]' WHERE id = 1;`
-    - exit
-<br>
+The table above is snippet how `realmlist` under `acore_auth` database looks.
+
+- `id` - Is a primary key (unique number per row), auto-incrementing (increases automatically when a new entry).
+- `name` - Is a unique key (unique column name), this refers to `Realm` name that appears in-game and `authserver`.
+- `address` - Referes to the machine hosting's [Public IP](http://www.whatismyip.com/), which is the IP people use to connect to your server (outside / externally of your network), for some cases is the **DNS** ("domain name").
+- `localAddress` - Referes to the machine hosting's **Local** / **LAN IP**, which is the IP you and other people use to connect to your server (within / inside of your network), for some cases where you're using **DNS** as your `address` field, you may use the machine hosting's [Public IP](http://www.whatismyip.com/) in `localAddress` field.
+- `localSubnetMask` - This only should be changed by people who know what they are doing, beginners shoudln't have to care about the correct usage SubnetMask for their IP category, so leave as it is.
+- `port` - This refers to `mysql` service port being used, by default is `8085` which is the default one in `mysql` also.
+
+If you leave the default values of `127.0.0.1` only the client in the same machine as that's hosting the server will be able to connect, for this cases where you wish to join from another computer in the same network make sure you change `localAddress` to match the **Local IP** of the machine that's hosting the server.
+
+Same applies for `address` but machine as that's hosting the server's [Public IP](http://www.whatismyip.com/) which is can be used to connect from a computer outside of the network, some routers have `hairpinning` which allow you to use machine's [Public IP](http://www.whatismyip.com/) to connect within the same network.
+
+`DNS` technical:
+- Fully qualified domain name - (mydomain.com or warcraft.mydomain.com) Similar to an external IP address, this would be used if you want other people to connect to your server with the added benefit of not needing to track a potentially dynamic IP address.
+- Similar to the Public IP address, it's likely that you'll need to set up port forwards if you're hosting from a home network.
+- Additionally, you'll need to configure DNS to point to the server's public IP address. Setting up DNS is out of the scope of this guide, though your domain registrar or dynamic DNS provider should have this documentation available.
+
+
+Using any of database client refered in the requirements page (HeidiSQL, MySQL command-line interface [CLI], etc... or others your choice) you may change any of column's values by a simple SQL query.
+
+### HeidiSQL (most popular for newer users of MySQL).
+- Click once in `acore_auth` within that database click once in `realmlist` and in the `Query` tab run the query below.
+
+Alternative you may use the UI by going to `Data` (not `Table: realmlist`) tab and change the values manually (by double clicking in them).
+
+### MySQL CLI (most popular for linux users.)
+- In your terminal of choice (example given for `CMD` of Windows, which is recommended to be ran as `Administrator`) 
+
+`mysql -u acore -p -h 127.0.0.1 acore_auth`
+
+(This will prompt your password after being executed)
+
+Example:
+
+```
+UPDATE `realmlist` SET `address` = "21.0.1.59", `localAddress` = "192.168.1.50"  WHERE `id` = 1;
+```
+
+This will change the [Public IP](http://www.whatismyip.com/) to `21.0.1.59` and the **Local IP** to `192.168.1.50` where the `Realm ID` is `1` (by default is `AzerothCore`).
 
 ## Help
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -11,7 +11,7 @@ This guide is intended for advanced setups or just to provide more details in se
 
 For the majority of the cases the default configuration values for `LoginDatabaseInfo`, `CharacterDatabaseInfo` and `WorldDatabaseInfo` should be left alone as `127.0.0.1` (also known as `localhost`, the current machine hosting/running the `authserver` and `worldserver`), the same goes for `BindIP` should be left alone as well as `0.0.0.0`.
 
-If you need to connect to your database from one external machine, read [this](https://www.enovision.net/mysql-ssh-tunnel-heidisql) instead open ports to the MySQL server.
+If you need to connect to your database from one external machine, read [this](https://www.enovision.net/mysql-ssh-tunnel-heidisql) instead of opening ports to the MySQL server.
 
 ### Port Forwarding (Incoming / Inbound)
 

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -94,19 +94,7 @@ You will need to go in the `Build` folder you created, under `\bin\RelWithDebInf
   - To relative / full path path: `DataDir = "C:\Build\bin\RelWithDebInfo\Data"`.
 
 
-For most `worldserver.conf` setting changes, you can simply type `.reload config` in-game to see changes instantly without restarting the server, the tables below are the tables that will take some effect after `.reload` command is executed.
-
-| Column 1 | Column 2 | Column 3 | Column 4 | Column 5 |
-|----------|----------|----------|----------|----------|
-| [acore_string](acore_string) | [achievement_criteria_data](achievement_criteria_data) | [command](command) | [creature_linked_respawn](creature_linked_respawn) | [creature_loot_template](creature_loot_template) |
-| [creature_movement_override](creature_movement_override) | [creature_onkill_reputation](creature_onkill_reputation) | [creature_questender](creature_questender) | [creature_queststarter](creature_queststarter) | [disables](disables) |
-| [dungeon_access_requirements](dungeon_access_requirements) | [dungeon_access_template](dungeon_access_template) | [event_scripts](event_scripts) | [game_event_npc_vendor](game_event_npc_vendor) | [game_graveyard](game_graveyard) |
-| [gameobject_loot_template](gameobject_loot_template) | [gameobject_queststarter](gameobject_queststarter) | [gameobject_questender](gameobject_questender) | [gossip_menu](gossip_menu) | [gossip_menu_option](gossip_menu_option) |
-| [graveyard_zone](graveyard_zone) | [item_enchantment_template](item_enchantment_template) | [item_loot_template](item_loot_template) | [item_set_names](item_set_names) | [module_string](module_string) |
-| [module_string_locale](module_string_locale) | [npc_vendor](npc_vendor) | [page_texts](page_texts) | [pickpocketing_loot_template](pickpocketing_loot_template) | [points_of_interest](points_of_interest) |
-| [quest_area_triggers](quest_area_triggers) | [quest_greeting](quest_greeting) | [quest_poi](quest_poi) | [quest_template](quest_template) | [reputation_reward_rate](reputation_reward_rate) |
-| [reputation_spillover_template](reputation_spillover_template) | [reference_loot_template](reference_loot_template) | [server_mail_template](server_mail_template) | [skinning_loot_template](skinning_loot_template) | [spell_scripts](spell_scripts) |
-| [waypoint_data](waypoint_data) | [waypoint_scripts](waypoint_scripts) | World config settings | AntiDos opcode policies |  |
+For most `worldserver.conf` setting changes, you can simply type `.reload config` in-game to see changes instantly without restarting the server.
 
 
 {% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -20,7 +20,7 @@ Some files are optional but highly recommended:
 | maps      | Mandatory          |
 | vmaps     | HIGHLY RECOMMENDED |
 | mmaps     | HIGHLY RECOMMENDED |
-| cameras   | Recommended        |
+| Cameras   | Recommended        |
 
 ## Option 1: Download Pre-Extracted Files
 
@@ -42,15 +42,17 @@ If you intend to use an english (`enUS` or `enGB`) client you can download the d
 
 1. Browse into your build directory (**C:\Build\bin\RelWithDebInfo\\**) and copy the following files into your World of Warcraft folder (where the wow.exe is located).
 ```
-mapextractor.exe
+map_extractor.exe
 mmaps_generator.exe
-vmap4extractor.exe
-vmap4assembler.exe
+vmap4_extractor.exe
+vmap4_assembler.exe
 ```
 
 2. Browse into **C:\Azerothcore\apps\extractor** and copy "**extractor.bat**" into your World of Warcraft folder with the previous files.
 
 3. Create **mmaps** and **vmaps** folders in your World of Warcraft directory.
+
+Note: To be able to generate your mmaps you will have to have present the `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`.
 
 4. Launch extractor.bat and select your extractor options.
 

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -24,7 +24,7 @@ Some files are optional but highly recommended:
 
 ## Option 1: Download Pre-Extracted Files
 
-If you intend to use an enUS client you can download the data files below. If you intend to use any other language client you will need to [extract](#option-2-extract-files-yourself) the data yourself.
+If you intend to use an english (`enUS` or `enGB`) client you can download the data files below. If you intend to use any other language client you will need to [extract](#option-2-extract-files-yourself) the data yourself.
 
 <a class="no-icon" href="https://github.com/wowgaming/client-data/releases/" target="_blank"><i class="fa-solid fa-download"></i> Data files enUS (AC Data v16)</a>
 
@@ -76,44 +76,42 @@ vmap4assembler.exe
 
 First of all you need to find the two default config files (named **worldserver.conf.dist** and **authserver.conf.dist**) and copy them. Then rename the copies their namesakes without the .dist extension. You can find them within C:\Build\bin\RelWithDebInfo\configs\ (may vary).
 
-Open the .conf files and scroll down to LoginDatabaseInfo, WorldDatabaseInfo, and CharacterDatabaseInfo and enter MySQL login information for the server to be able to access your database.
+You will need to go in the `Build` folder you created, under `\bin\RelWithDebInfo\configs` and make a copy and rename the copies to the following:
+`worldserver.conf.dist - Copy` to `worldserver.conf`
+`authserver.conf.dist - Copy` to `authserver.conf`
 
-On a newly compiled configuration, you will have the following values by default
-```
-LoginDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_auth" worldserver.conf / authserver.conf
-WorldDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_world" worldserver.conf
-CharacterDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_characters" worldserver.conf
-```
+{% include tip.html content="In the case you made the copies and it still giving you errors because it doesnt find either config, make sure you've -Hide extensions for known file types- unchecked in your windows folder options, and you can validate if the file names are correct." %}
 
-They follow this structure:
 
-```
-Variablename = "MySQLIP;Port;Username;Password;database"  
-``` 
+## Updating DataDir / Data Directory
 
-The following steps must be verified:
+1. In your `worldserver.conf` file locate the `DataDir` option.
 
-- The hostname (127.0.0.1) can stay the same if AzerothCore is being installed on the same computer that you run WoW on.
-  If not, follow the instruction in [Realmlist Table](realmlist).
+2. Edit it to the path of your folder the following examples below:
+  - Current folder, if the `Data` folder is in the same place as your `authserver` and `worldserver` setting `DataDir = "./Data"`. 
 
-- The port (3306) is the standard configured value. If you changed the default port in your MySQL settings, you must change it accordingly.
-  The username and password can be variable. You can choose to either: 
 
-    - use default acore / acore username and password pair.
+  - To relative / full path path: `DataDir = "C:\Build\bin\RelWithDebInfo\Data"`.
 
-    - create a unique login within a User Manager within your preferred database management tool (commonly identified by an icon that looks like a person or people) and give it the necessary permissions (SELECT, INSERT, UPDATE, DELETE permissions are sufficient, and is much safer).
 
-### Updating DataDir
+For most `worldserver.conf` setting changes, you can simply type `.reload config` in-game to see changes instantly without restarting the server, the tables below are the tables that will take some effect after `.reload` command is executed.
 
-1. In your **worldserver.conf** file locate the **DataDir** option.
+| Column 1 | Column 2 | Column 3 | Column 4 | Column 5 |
+|----------|----------|----------|----------|----------|
+| [acore_string](acore_string) | [achievement_criteria_data](achievement_criteria_data) | [command](command) | [creature_linked_respawn](creature_linked_respawn) | [creature_loot_template](creature_loot_template) |
+| [creature_movement_override](creature_movement_override) | [creature_onkill_reputation](creature_onkill_reputation) | [creature_questender](creature_questender) | [creature_queststarter](creature_queststarter) | [disables](disables) |
+| [dungeon_access_requirements](dungeon_access_requirements) | [dungeon_access_template](dungeon_access_template) | [event_scripts](event_scripts) | [game_event_npc_vendor](game_event_npc_vendor) | [game_graveyard](game_graveyard) |
+| [gameobject_loot_template](gameobject_loot_template) | [gameobject_queststarter](gameobject_queststarter) | [gameobject_questender](gameobject_questender) | [gossip_menu](gossip_menu) | [gossip_menu_option](gossip_menu_option) |
+| [graveyard_zone](graveyard_zone) | [item_enchantment_template](item_enchantment_template) | [item_loot_template](item_loot_template) | [item_set_names](item_set_names) | [module_string](module_string) |
+| [module_string_locale](module_string_locale) | [npc_vendor](npc_vendor) | [page_texts](page_texts) | [pickpocketing_loot_template](pickpocketing_loot_template) | [points_of_interest](points_of_interest) |
+| [quest_area_triggers](quest_area_triggers) | [quest_greeting](quest_greeting) | [quest_poi](quest_poi) | [quest_template](quest_template) | [reputation_reward_rate](reputation_reward_rate) |
+| [reputation_spillover_template](reputation_spillover_template) | [reference_loot_template](reference_loot_template) | [server_mail_template](server_mail_template) | [skinning_loot_template](skinning_loot_template) | [spell_scripts](spell_scripts) |
+| [waypoint_data](waypoint_data) | [waypoint_scripts](waypoint_scripts) | World config settings | AntiDos opcode policies |  |
 
-1. Edit it to the path of your folder. i.e **C:\Build\bin\RelWithDebInfo\Data**
-
-{% include tip.html content="For most **worldserver.conf** setting changes, you can simply type .reload config in-game to see changes instantly without restarting the server." %}
 
 {% include warning.html content="The AzerothCore Team and Owners DO NOT in any case sponsor nor support illegal public servers. If you use these projects to run an illegal public server and not for testing and learning it is your own personal choice." %}
 
-### (Optional) Config options by environment variable
+## (Optional) Config options by environment variable
 
 It is possible to load config options via environment variables, which you can read about [here](config-overrides-with-env-var).
 

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -52,7 +52,7 @@ vmap4_assembler.exe
 
 3. Create **mmaps** and **vmaps** folders in your World of Warcraft directory.
 
-Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, in the case it's not present automatically, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
 
 4. Launch extractor.bat and select your extractor options.
 

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -52,7 +52,7 @@ vmap4_assembler.exe
 
 3. Create **mmaps** and **vmaps** folders in your World of Warcraft directory.
 
-Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`, if you wish to customise some mmaps settings refer to [mmaps-config](mmaps-config) page.
 
 4. Launch extractor.bat and select your extractor options.
 

--- a/docs/windows-server-setup.md
+++ b/docs/windows-server-setup.md
@@ -52,7 +52,7 @@ vmap4_assembler.exe
 
 3. Create **mmaps** and **vmaps** folders in your World of Warcraft directory.
 
-Note: To be able to generate your mmaps you will have to have present the `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`.
+Note: To be able to generate your mmaps you will have to have present the file `mmaps-config.yaml` in the same place as your `mmaps_generator.exe`, you can find the YAML file in `C:\Azerothcore\src\tools\mmaps_generator`.
 
 4. Launch extractor.bat and select your extractor options.
 


### PR DESCRIPTION
Changed files:
- windows-server-setup.md
- database-installation.md
- networking.md
- final-server-steps.md

# windows-server-setup.md
- Clarified that `Data` used can work aside also `enGB`
- Clarified the `copy X config dist and change the name removing .dist` 
- Added Tip for Windows Extension Hide/Show check 
- Removed complety config - database related stuff and moved into `database` instalation
- Clear instruction on `DataDir` part.
- Expanded on `reload` information, including all reloadable tables

# database-installation.md
- Expanded into more detail and examples how to actually run the query
- Examples for HeidiSQL and CLI (which also works for linux users)
- Path example of binaries of both Windows and Linux users (also no longer windows.exe when refering to other OSes that arent windows.
-  config - database related stuff  from windows-server
- Changing the orders of database populatuion (to have automatic first)
- Moved sql-directoy information below it
- Tip note for anyone who wishes to "re-do" the database by dropping them

# networking-md
- Better explaining / clarification for the average user doesn't need to change certain information.
- Having a table dedicated for the PORTS instead of just lost in the middle of text.
- Note to NOT open 8085 or any other mysql ports if the user doesnt know what's doing.
- Expanded on the connection/network part for `realmlist` 
- Examples , explantion for both heidi and mysql cli

# final-server-steps-md
- Mentioned of windows and linux binaries path
- Specfication for auto-restart being a linux env only thing
- Creating account was moved up and removed any previous text that duplicates what the wiki alrreadys says.
- Clarification of `3.3.5` and not higher (modern versions of wotlk), `realmlist` path and file name and what to do.
- Tip saying for windows extension show/hide check
- Clarification on login (username and password)
- Tip saying realm stuck for windows user (on the same machine / localhost as client and server) being QuickEdit mode from CLI of windows from 10 and above
- Expanded on GM commands section by providing the wiki link
- Added wowhead version of ac (aowow from wowgaming)
- Mention of examples for simple php account creation logic
- Mentioned of the catalogue
