### PR TITLE
Revise compact queries section for clarity

### DIFF
--- a/docs/sql-standards.md
+++ b/docs/sql-standards.md
@@ -107,9 +107,7 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 
 ### Compact queries
 
-We always aim to keep the code as compact as possible, reducing file size and minimising the number of queries required. While this is generally good practice, bundling queries in a way that complicates review is counterproductive. For instance, mixing different SAI entities makes the code significantly harder to review and more prone to user error.
-
-The goal is to keep the queries compact, but not at the expense of making them harder to review.
+We always aim to keep the code as compact as possible, reducing file size and minimising the number of queries required. While this is generally good practice, bundling queries in a way that complicates review is counterproductive. For instance, mixing different SAI entities makes the code significantly harder to review and more prone to user error, so try to keep the queries compact, but not at the expense of making them harder to review.
 
 Wrong:
 


### PR DESCRIPTION
This pull request updates the SQL standards documentation to clarify best practices for writing compact queries. The main change is a revision of the guidance on query compactness, emphasizing that queries should remain easy to review and not be bundled in a way that increases complexity or risk of errors.

Documentation improvements:

* Updated the "Compact queries" section in `docs/sql-standards.md` to clarify that while compact code is preferred, it should not come at the cost of reviewability or maintainability. The new guidance discourages bundling unrelated queries, especially those involving different SAI entities, as this can complicate reviews and increase the chance of user error.

End of copilot generated summary.

AI off:
* **Keeps the entry barrier low, allowing Keira users to contribute without editing SQL files.**
* **Avoids bothering contributors over trivial details that make little difference, except when inserting hundreds of rows.**
* **The standard rule remains a “nice-to-have” rather than strictly enforced, since 1) it’s not always possible, 2) not always desirable, and 3) rarely makes a meaningful difference.**

<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

- 
- 

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
