### PR TITLE
Update documentation about re-building on linux and number of workers

### DIFF
--- a/docs/linux-keeping-the-server-up-to-date.md
+++ b/docs/linux-keeping-the-server-up-to-date.md
@@ -16,8 +16,9 @@ Rebuild the changes you pulled.
 
 ```sh
 cd build
-make -j 8; make install
+make -j$(nproc --all); make install
 ```
+_You can replace `-j$(nproc -all)` with the number of cores to build with. For example: -j 2_
 
 Sometimes we add or remove files from the repository. At that point it is necessary to recompile the server, the same way as it was installed the first time [in the Linux Core Installation](linux-core-installation#configuring-for-compiling).
 


### PR DESCRIPTION
### Description

- Update the -j option for make to default in the instructions to use all cores available instead of hard-coding '8'.
-  Added a description in italics underneath to let the user know what the option does and how to override it. This follows a slightly different procedure from the linux build page, which exports a variable in the shell environment, but I think this is a little more straightforward.

@pangolp There is text added here that would need translation to Spanish. If it is deemed redundant and authors wish to eliminate so we don't need a translation, that works for me, otherwise a Spanish translation will be needed. I can also change the grammar of the sentence if that makes translation more accurate.
