### PR TITLE
docs: Correct spelldifficulty_dbc column names

### DIFF
--- a/docs/spelldifficulty_dbc.md
+++ b/docs/spelldifficulty_dbc.md
@@ -10,17 +10,17 @@ This table contains spell data regarding cpp scripts. The id is called in the sc
 
 | Field         | Type | Attributes | Key | Null | Default | Extra | Comment |
 | ------------- | ---- | ---------- | --- | ---- | ------- | ----- | ------- |
-| [id][1]       | INT  | UNSIGNED   | PRI | NO   | 0       |       |         |
-| [spellid0][2] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
-| [spellid1][3] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
-| [spellid2][4] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
-| [spellid3][5] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
+| [ID][1]       | INT  | UNSIGNED   | PRI | NO   | 0       |       |         |
+| [DifficultySpellID_1][2] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
+| [DifficultySpellID_2][3] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
+| [DifficultySpellID_3][4] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
+| [DifficultySpellID_4][5] | INT  | UNSIGNED   |     | NO   | 0       |       |         |
 
 [1]: #id
-[2]: #spellid0
-[3]: #spellid1
-[4]: #spellid2
-[5]: #spellid3
+[2]: #difficultyspellid_1
+[3]: #difficultyspellid_2
+[4]: #difficultyspellid_3
+[5]: #difficultyspellid_4
 
 **Description of the fields**
 
@@ -28,18 +28,18 @@ This table contains spell data regarding cpp scripts. The id is called in the sc
 
 id referenced in the cpp script for the creature AI.
 
-### spellid0
+### DifficultySpellID_1
 
 Spell ID to be used in normal dungeon (or normal 10men raid).
 
-### spellid1
+### DifficultySpellID_2
 
 Spell ID to be used in heroic dungeon (or normal 25men raid).
 
-### spellid2
+### DifficultySpellID_3
 
 Spell ID to be used in heroic 10men raid.
 
-### spellid3
+### DifficultySpellID_4
 
 Spell ID to be used in heroic 25men raid.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

- Corrected column names in `spelldifficulty_dbc` table documentation
- Updated field names from `id`, `spellid0-3` to `ID`, `DifficultySpellID_1-4` to match actual database schema

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->
