### PR TITLE
docs: Add breadcrumb quest documentation with cross-links

### DIFF
--- a/docs/quest_template_addon.md
+++ b/docs/quest_template_addon.md
@@ -68,6 +68,8 @@ Allows to define a group of quests of which all must be completed and rewarded t
 
 Note: All quests that use an ExclusiveGroup must also have entries in [pool_template](pool_template) and [pool_quest](quest_template#examples-dealing-with-quests) for examples.
 
+**Important:** ExclusiveGroup should NOT be used for breadcrumb quests. Use [conditions](conditions#breadcrumb-quests) instead to properly handle optional lead-in quests.
+
 ### RewardMailTemplateID
 
 If the quest gives as a reward an item from a possible list of items, the ID here corresponds to the proper loot template in [quest_mail_loot_template](loot_template). According to the rules in that loot template, items "looted" will be sent by mail at the completion of the quest.


### PR DESCRIPTION
## Summary
- Add warning to `quest_template_addon` ExclusiveGroup section about not using it for breadcrumb quests
- Add "Breadcrumb Quests" section to `conditions.md` with example SQL and field-by-field explanation
- Cross-link both pages for easy navigation

## Context
This documentation was created after fixing [issue #23846](https://github.com/azerothcore/azerothcore-wotlk/issues/23846) where ExclusiveGroup was incorrectly used for a breadcrumb quest, causing a regression. The fix (PR #24077) uses conditions instead, and this wiki update documents the correct approach for future reference.

## Changes
**quest_template_addon.md:**
- Added warning under ExclusiveGroup that breadcrumb quests should use conditions instead

**conditions.md:**
- Added new "Breadcrumb Quests" section explaining:
  - What breadcrumb quests are
  - Why ExclusiveGroup is wrong for breadcrumbs
  - The correct approach using CONDITION_SOURCE_TYPE_QUEST_AVAILABLE
  - Real SQL example from quests 11287/11286
  - Field-by-field explanation of the condition values