### PR TITLE
Add warning for Docker users to networking.md

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -36,6 +36,8 @@ You need to make sure that your **authserver** application directs incoming conn
         - Similar to the Public IP address, it's likely that you'll need to set up port forwards if you're hosting from a home network.
         - Additionally, you'll need to configure DNS to point to the server's public IP address. Setting up DNS is out of the scope of this guide, though your domain registrar or dynamic DNS provider should have this documentation available.
 
+{% include warning.html content="Do not change the localAddress field from its default value if using Docker." %}
+
 {% include note.html content="If you are using HeidiSQL, make sure you are in the Data tab when you edit values." %}
 
  - MySQL CLI Commands (This step is not needed if you used a MySQL Manager like HeidiSQL)

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -36,7 +36,7 @@ You need to make sure that your **authserver** application directs incoming conn
         - Similar to the Public IP address, it's likely that you'll need to set up port forwards if you're hosting from a home network.
         - Additionally, you'll need to configure DNS to point to the server's public IP address. Setting up DNS is out of the scope of this guide, though your domain registrar or dynamic DNS provider should have this documentation available.
 
-{% include warning.html content="Do not change the localAddress field from its default value if using Docker." %}
+{% include warning.html content="<b>Docker only:</b> Do not change the localAddress field from its default value." %}
 
 {% include note.html content="If you are using HeidiSQL, make sure you are in the Data tab when you edit values." %}
 


### PR DESCRIPTION
Add an admonition to leave `localAddress` unchanged in the `realmlist` if following the Docker setup guide. 

### Description

I found myself in a situation where I was getting silent connection failures because I'd changed the `localAddress` field to match my physical LAN interface when I was using Docker.

This adds a warning admonition to leave it unchanged if using Docker.

@pangolp I don't speak Spanish so, if this is committed, I'll need your help.