### PR TITLE
docs: add text output section to C++ code standards

### DIFF
--- a/docs/cpp-code-standards.md
+++ b/docs/cpp-code-standards.md
@@ -332,7 +332,9 @@ All Header files should contain header guards
 
 ### Text Output
 
-All script text output must use [acore_string](acore_string) whenever possible (e.g., command handlers, script messages).
+All C++ script/system/command text output must use [acore_string](acore_string) whenever possible (e.g., ChatHandler messages, script system messages).
+
+NPC dialog, emotes, and other in-game text that is managed via database text systems (such as `creature_text`, `broadcast_text`, etc.) should continue to use those systems instead of `acore_string`.
 
 When adding new strings, localization must be provided for all available languages.
 


### PR DESCRIPTION
This pull request adds a new section to the `docs/cpp-code-standards.md` file, introducing guidelines for text output and localization in scripts. The update emphasizes the use of `acore_string` for script text output and requires localization for all new strings.

Text output and localization guidelines:

* Added a section recommending the use of `acore_string` for all script text output, such as command handlers and script messages.
* Established a requirement for providing localization for all new strings in all available languages, with a tip suggesting the use of AI for translation assistance.
