### PR TITLE
docs: Add code standard guidelines for #include

### DIFF
--- a/docs/cpp-code-standards.md
+++ b/docs/cpp-code-standards.md
@@ -358,7 +358,7 @@ ItemEnchantmentMgr.cpp example:
 
 Alphabetical ordering is case-sensitive (ASCII order, matching clang-format's default): uppercase letters sort before lowercase. Above, `DBCStores.h` precedes `DatabaseEnv.h` because the uppercase `B` sorts before the lowercase `a`.
 
-Project headers use quotes (`"..."`); library headers (C++ standard library, boost, etc.) use angle brackets (`<...>`).
+Project headers use quotes (`"..."`); library headers (C++ standard library, boost, etc.) use angle brackets (`<...>`). A third-party library bundled into the codebase, such as G3D, is the exception and uses quotes.
 
 ### Text Output
 

--- a/docs/cpp-code-standards.md
+++ b/docs/cpp-code-standards.md
@@ -53,7 +53,7 @@ if (a == b)
 
 Trailing whitespace is not allowed.
 
-You should also not have unneeded spaces within a bracket. 
+You should also not have unneeded spaces within a bracket.
 
 Wrong:
 
@@ -329,6 +329,36 @@ All Header files should contain header guards
 
 #endif // MY_HEADER_H
 ```
+
+### Includes
+
+Every header must be **self-contained**: it must compile on its own, without depending on other headers being included before it. This prevents hidden fragile dependencies. If "A" needs "B" and "C", it should include "B" & "C". It shouldn't only include "B", just because "B" happened to include "C" right now. "A" should also not include anything it doesn't directly use.
+
+Includes are written as a single block with no blank lines inside it, ordered as follows:
+
+1. The file's own header first in the .cpp (if the .cpp needs to include its own header).
+2. All other project headers, in alphabetical order.
+3. All library headers, in alphabetical order.
+
+ItemEnchantmentMgr.cpp example:
+
+```cpp
+#include "ItemEnchantmentMgr.h"   // The file's own header, first
+#include "DBCStores.h"            // then project headers, alphabetically
+#include "DatabaseEnv.h"
+#include "Log.h"
+#include "ObjectMgr.h"
+#include "QueryResult.h"
+#include "Timer.h"
+#include "Util.h"
+#include <cmath>                  // then library headers, alphabetically
+#include <functional>
+#include <vector>
+```
+
+Alphabetical ordering is case-sensitive (ASCII order, matching clang-format's default): uppercase letters sort before lowercase. Above, `DBCStores.h` precedes `DatabaseEnv.h` because the uppercase `B` sorts before the lowercase `a`.
+
+Project headers use quotes (`"..."`); library headers (C++ standard library, boost, etc.) use angle brackets (`<...>`).
 
 ### Text Output
 

--- a/docs/cpp-code-standards.md
+++ b/docs/cpp-code-standards.md
@@ -332,7 +332,7 @@ All Header files should contain header guards
 
 ### Includes
 
-Every header must be **self-contained**: it must compile on its own, without depending on other headers being included before it. This prevents hidden fragile dependencies. If "A" needs "B" and "C", it should include "B" & "C". It shouldn't only include "B", just because "B" happened to include "C" right now. "A" should also not include anything it doesn't directly use.
+Every header must be **self-contained**: it must compile on its own, without depending on other headers being included before it. This prevents hidden fragile dependencies. If `A` needs `B` and `C`, it should include both `B` and `C`. It shouldn't only include `B` just because `B` happens to include `C` right now. `A` should also not include anything it doesn't directly use.
 
 Includes are written as a single block with no blank lines inside it, ordered as follows:
 
@@ -356,9 +356,36 @@ ItemEnchantmentMgr.cpp example:
 #include <vector>
 ```
 
-Alphabetical ordering is case-sensitive (ASCII order, matching clang-format's default): uppercase letters sort before lowercase. Above, `DBCStores.h` precedes `DatabaseEnv.h` because the uppercase `B` sorts before the lowercase `a`.
+Alphabetical ordering is case-sensitive (ASCII order): uppercase letters sort before lowercase. Above, `DBCStores.h` precedes `DatabaseEnv.h` because the uppercase `B` sorts before the lowercase `a`.
 
-Project headers use quotes (`"..."`); library headers (C++ standard library, boost, etc.) use angle brackets (`<...>`). A third-party library bundled into the codebase, such as G3D, is the exception and uses quotes.
+Project headers use quotes (`"..."`); library headers (C++ standard library, boost, etc.) use angle brackets (`<...>`). A third-party library bundled into the codebase, such as G3D, is the exception and uses quotes, but it still sorts with the library headers rather than with the project headers.
+
+WaypointDefines.h example:
+
+```cpp
+#include "Define.h"          // project headers, alphabetically
+#include "G3D/Vector3.h"     // then library headers, alphabetically
+#include <optional>
+#include <vector>
+```
+
+Conditionally compiled includes are the exception to the single-block rule. Keep every unconditional include together in one sorted block, then place `#if` / `#ifdef` guarded includes after it, separated by a blank line. Do not break up the sorted block to keep a guarded include next to a related one.
+
+Errors.cpp example (shortened):
+
+```cpp
+#include "Errors.h"
+#include "Duration.h"
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+#if AC_PLATFORM == AC_PLATFORM_WINDOWS
+#include <Windows.h>
+#endif
+```
+
+Only guard an include when the header itself is platform or configuration specific. Never wrap an ordinary include in a guard to work around a build error elsewhere, and never leave out an include because some other header happens to pull it in under the current configuration, that is exactly the hidden dependency the self-contained rule prevents.
 
 ### Text Output
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.
Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
English: https://www.azerothcore.org/wiki/wiki-standards
Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
-->

### Description

The codebase is (mostly) consistent in the way includes are formatted. Now there are formal guidelines. Most critically highlighting that headers need to self-contained, but also what order includes should be added in for ease of readability. 

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

<!-- If you are making a change to a file that requires an update to Spanish or you are creating one, please, if you can, within the pull request or the chat itself, tag or mention @pangolp so that he can create/update the file to Spanish as well. Thank you. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified C++ code standards for whitespace and within-bracket spacing.
  * Added guidance that each header is self-contained (compilable without prior includes).
  * Documented a strict `#include` block order: own header first, then project headers alphabetically, then library headers alphabetically (with an example).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->