### PR TITLE
docs(es): Fix duplicated /es/ in relative links

### DIFF
--- a/docs/es/ac-dashboard-core-installation.md
+++ b/docs/es/ac-dashboard-core-installation.md
@@ -4,7 +4,7 @@ El dashboard Bash de AzerothCore es una colección de scripts que ayudan con la 
 Permite instalar, actualizar y ejecutar AzerothCore fácilmente en tu máquina en una cantidad de pasos tremendamente pequeña.
 
 Instalar un servidor privado de desarrollo o producción nunca había sido tan fácil.
-Si necesitas cualquier ayuda, simplemente [haz una pregunta](es/how-to-ask-for-help).
+Si necesitas cualquier ayuda, simplemente [haz una pregunta](how-to-ask-for-help).
 
 
 ## Requisitos
@@ -104,7 +104,7 @@ Los binarios `worldserver` y `authserver` están ubicados en `azerothcore-wotlk/
 Puedes ejecutarlos directamente o usar el reiniciador (ver abajo).
 El primer arranque del `worldserver` instalará una base de datos completa de AzerothCore. No es necesario importar ninguna actualización de la base de datos en este punto.
 
-Consulta también [Red](es/networking) y [Pasos finales del servidor](es/final-server-steps).
+Consulta también [Red](networking) y [Pasos finales del servidor](final-server-steps).
 
 ### Reiniciador
 
@@ -139,7 +139,7 @@ Reconstruye:
 
 Actualiza la base de datos:
 
-[database-keeping-the-server-up-to-date](es/database-keeping-the-server-up-to-date)
+[database-keeping-the-server-up-to-date](database-keeping-the-server-up-to-date)
 
 Eso es todo.
 

--- a/docs/es/ac-new-example.md
+++ b/docs/es/ac-new-example.md
@@ -3,7 +3,7 @@
 | Guía de instalación                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | Este artículo forma parte de la Guía de instalación. Puedes leerlo por separado o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |                                                           |
-| [<< Inicio: Guía de instalación](es/classic-installation)                                                                                 | [Paso 2: Instalación del Core >>](es/windows-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation)                                                                                 | [Paso 2: Instalación del Core >>](windows-core-installation) |
 
 {% include callout.html content="Windows ≥ 10<br/>
 Boost ≥ 1.78<br/>
@@ -182,15 +182,15 @@ While installing OpenSSL, choose The OpenSSL binaries (/bin) directory (NOT "The
 
 Si sigues teniendo problemas, revisa:
 
-- [FAQ](es/faq)
+- [FAQ](faq)
 
-- [Errores comunes](es/common-errors)
+- [Errores comunes](common-errors)
 
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación                                                                                                                   |                                                           |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
 | Este artículo forma parte de la Guía de instalación. Puedes leerlo por separado o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |                                                           |
-| [<< Inicio: Guía de instalación](es/classic-installation)                                                                                 | [Paso 2: Instalación del Core >>](es/windows-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation)                                                                                 | [Paso 2: Instalación del Core >>](windows-core-installation) |

--- a/docs/es/account.md
+++ b/docs/es/account.md
@@ -227,7 +227,7 @@ El nombre del personaje con los derechos o el poder sobre el comando .mute que d
 
 ### locale
 
-La configuración regional utilizada por el cliente conectado a esta cuenta. Si se han configurado y añadido múltiples datos de localización a los servidores mundiales, éstos devolverán al cliente las cadenas de localización adecuadas. Ver [IDs de localización](es/Localization_lang)
+La configuración regional utilizada por el cliente conectado a esta cuenta. Si se han configurado y añadido múltiples datos de localización a los servidores mundiales, éstos devolverán al cliente las cadenas de localización adecuadas. Ver [IDs de localización](Localization_lang)
 
 ### os
 

--- a/docs/es/antidos_opcode_policies.md
+++ b/docs/es/antidos_opcode_policies.md
@@ -1,6 +1,6 @@
 # antidos_opcode_policies
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Estructura**
 

--- a/docs/es/classic-installation.md
+++ b/docs/es/classic-installation.md
@@ -3,40 +3,40 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Instalación](es/installation) | [Paso 1: Requisitos >>](es/requirements) |
+| [<< Inicio: Instalación](installation) | [Paso 1: Requisitos >>](requirements) |
 
 La guía se ha dividido en 9 pasos, para hacerla más legible.
 
 {% include tip.html content="Cada paso puede leerse de forma independiente. Si es la primera vez que instalas AzerothCore, te recomendamos que leas cada paso con atención." %}
 
-1. [Requisitos](es/requirements)
+1. [Requisitos](requirements)
 
-2. [Instalación del Core](es/core-installation)
+2. [Instalación del Core](core-installation)
 
-3. [Configuración del servidor](es/server-setup)
+3. [Configuración del servidor](server-setup)
 
-4. [Instalación de la base de datos](es/database-installation)
+4. [Instalación de la base de datos](database-installation)
 
-5. [Red](es/networking)
+5. [Red](networking)
 
-6. [Pasos finales del servidor](es/final-server-steps)
+6. [Pasos finales del servidor](final-server-steps)
 
-7. [Mantener el servidor actualizado](es/keeping-the-server-up-to-date)
+7. [Mantener el servidor actualizado](keeping-the-server-up-to-date)
 
-8. [Configuración del cliente](es/client-setup)
+8. [Configuración del cliente](client-setup)
 
-9. [(Opcional) Instalar un módulo](es/installing-a-module)
+9. [(Opcional) Instalar un módulo](installing-a-module)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Instalación](es/installation) | [Paso 1: Requisitos >>](es/requirements) |
+| [<< Inicio: Instalación](installation) | [Paso 1: Requisitos >>](requirements) |

--- a/docs/es/client-setup.md
+++ b/docs/es/client-setup.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. | Opcional |
-| [<< Paso 7: Mantener el servidor actualizado](es/keeping-the-server-up-to-date) | [Paso 9: Instalar un módulo >>](es/installing-a-module) |
+| [<< Paso 7: Mantener el servidor actualizado](keeping-the-server-up-to-date) | [Paso 9: Instalar un módulo >>](installing-a-module) |
 
 AzerothCore no distribuye un cliente. Necesitarás encontrar tu propio cliente 3.3.5a limpio en internet.
 
@@ -21,12 +21,12 @@ AzerothCore no distribuye un cliente. Necesitarás encontrar tu propio cliente 3
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 7: Mantener el servidor actualizado](es/keeping-the-server-up-to-date) | [Paso 9: Instalar un módulo >>](es/installing-a-module) |
+| [<< Paso 7: Mantener el servidor actualizado](keeping-the-server-up-to-date) | [Paso 9: Instalar un módulo >>](installing-a-module) |

--- a/docs/es/command.md
+++ b/docs/es/command.md
@@ -1,6 +1,6 @@
 # command
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla `command`**
 
@@ -22,7 +22,7 @@ Contiene información de ayuda y de seguridad para los comandos. Esta tabla NO c
 
 ### name
 
-El nombre del comando. Ver: [comandos incluidos](es/gm-commands)
+El nombre del comando. Ver: [comandos incluidos](gm-commands)
 
 ### security
 

--- a/docs/es/common-errors.md
+++ b/docs/es/common-errors.md
@@ -4,7 +4,7 @@ tableofcontents: 1
 
 # Errores comunes
 
-| ¿Esta página no respondió a tus dudas? Lee [Cómo pedir ayuda](es/how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
+| ¿Esta página no respondió a tus dudas? Lee [Cómo pedir ayuda](how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
 | --- |
 
 ## Errores relacionados con la base de datos
@@ -16,7 +16,7 @@ No puedo iniciar mi Auth/WorldServer, me aparece:
 [ERROR]: Table 'acore_world.table' doesn't exist
 Your database structure is not up to date. Please make sure you've executed all queries in the sql/updates folders.
 ```
-Simplemente no estás actualizado y necesitas [actualizar tu base de datos](es/database-keeping-the-server-up-to-date).
+Simplemente no estás actualizado y necesitas [actualizar tu base de datos](database-keeping-the-server-up-to-date).
 
 ---
 
@@ -41,7 +41,7 @@ No puedo iniciar mi Auth/WorldServer, me aparece:
 ```
 > Loaded 0 acore strings. DB table `acore_string` is empty.
 ```
-Esto se debe a que no has importado la base de datos en absoluto. Sigue las instrucciones de [Instalación de la base de datos](es/database-installation)
+Esto se debe a que no has importado la base de datos en absoluto. Sigue las instrucciones de [Instalación de la base de datos](database-installation)
 
 ---
 
@@ -89,7 +89,7 @@ The code execution cannot proceed because libmysql.dll was not found. Reinstalli
 
 Or similar error.
 ```
-No has copiado los archivos .dll necesarios en el directorio de los binarios. Consulta [Instalación del Core](es/core-installation).
+No has copiado los archivos .dll necesarios en el directorio de los binarios. Consulta [Instalación del Core](core-installation).
 
 ---
 
@@ -131,7 +131,7 @@ Me aparece un error cuando inicia el WorldServer:
 ```
 Used MySQL library version (8.0.19 id 80019) does not match the version id used to compile AzerothCore (id 80024)
 ```
-Necesitas usar exactamente la misma versión de libmysql.dll que la versión que usaste para compilar tu código fuente. La obtienes de **C:\Program Files\MySQL\MySQL Server 8.x\lib\\** o siguiendo la [guía de instalación](es/windows-core-installation#compiling-the-source).
+Necesitas usar exactamente la misma versión de libmysql.dll que la versión que usaste para compilar tu código fuente. La obtienes de **C:\Program Files\MySQL\MySQL Server 8.x\lib\\** o siguiendo la [guía de instalación](windows-core-installation#compiling-the-source).
 
 Esto se debe a que has actualizado tu servidor MySQL pero no has recompilado ni añadido el nuevo archivo libmysql.dll.
 
@@ -331,7 +331,7 @@ Si obtienes un error de que *CMake could NOT find OpenSSL*
 
         - Especifica la ruta a git.exe, p. ej. `C:/Program Files/Git/cmd/git.exe`
 
-    - Si no tienes git.exe, necesitas instalar git. Consulta [requisitos](es/requirements)
+    - Si no tienes git.exe, necesitas instalar git. Consulta [requisitos](requirements)
 
 ---
 
@@ -347,5 +347,5 @@ Si obtienes un error de que *CMake could NOT find OpenSSL*
 
 ---
 
-| ¿Esta página no respondió a tus dudas? Lee [Cómo pedir ayuda](es/how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
+| ¿Esta página no respondió a tus dudas? Lee [Cómo pedir ayuda](how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
 | --- |

--- a/docs/es/conditions.md
+++ b/docs/es/conditions.md
@@ -1,6 +1,6 @@
 # conditions
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla \`conditions\`**
 

--- a/docs/es/contribute.md
+++ b/docs/es/contribute.md
@@ -12,7 +12,7 @@ Puedes contribuir de varias formas a AzerothCore:
 
 - [Probar un pull request](#how-to-test-a-pull-request)
 
-- [Probar cambios solo de base de datos](es/how-to-test-db-only-changes)
+- [Probar cambios solo de base de datos](how-to-test-db-only-changes)
 
 - [Crear un pull request](#how-to-create-a-pull-request)
 
@@ -44,12 +44,12 @@ Si **(y solo si)** el bug aún no ha sido reportado, puedes [abrir un issue](htt
 
 ## Cómo probar un Pull Request {#how-to-test-a-pull-request}
 
-- Lee [Cómo probar un PR](es/how-to-test-a-pr).
+- Lee [Cómo probar un PR](how-to-test-a-pr).
 
 ## Cómo crear un Pull Request {#how-to-create-a-pull-request}
 
-- Lee [Cómo crear un PR](es/how-to-create-a-pr).
-- Alternativamente, también puedes consultar [este tutorial más simple](es/how-to-create-a-db-pr) sobre cómo abrir pull requests que contienen código SQL a través de GitHub.
+- Lee [Cómo crear un PR](how-to-create-a-pr).
+- Alternativamente, también puedes consultar [este tutorial más simple](how-to-create-a-db-pr) sobre cómo abrir pull requests que contienen código SQL a través de GitHub.
 
 ### Dando crédito al autor del código
 

--- a/docs/es/core-installation.md
+++ b/docs/es/core-installation.md
@@ -3,24 +3,24 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/requirements) | [Paso 3: Configuración del servidor >>](es/server-setup) |
+| [<< Paso 1: Requisitos](requirements) | [Paso 3: Configuración del servidor >>](server-setup) |
 
-[Instalación del Core en Linux](es/linux-core-installation)
+[Instalación del Core en Linux](linux-core-installation)
 
-[Instalación del Core en macOS](es/macos-core-installation)
+[Instalación del Core en macOS](macos-core-installation)
 
-[Instalación del Core en Windows](es/windows-core-installation)
+[Instalación del Core en Windows](windows-core-installation)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/requirements) | [Paso 3: Configuración del servidor >>](es/server-setup) |
+| [<< Paso 1: Requisitos](requirements) | [Paso 3: Configuración del servidor >>](server-setup) |

--- a/docs/es/database-installation.md
+++ b/docs/es/database-installation.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 3: Configuración del servidor](es/server-setup) | [Paso 5: Red >>](es/networking) |
+| [<< Paso 3: Configuración del servidor](server-setup) | [Paso 5: Red >>](networking) |
 
 ## Crear la base de datos en MySQL
 
@@ -20,7 +20,7 @@ https://github.com/azerothcore/azerothcore-wotlk/blob/master/data/sql/create/cre
 
 ## Cargar datos en la base de datos
 
-Si quieres saber cómo funciona el directorio SQL o planeas hacer cambios personalizados, te recomendamos leer [esto](es/sql-directory).
+Si quieres saber cómo funciona el directorio SQL o planeas hacer cambios personalizados, te recomendamos leer [esto](sql-directory).
 
 #### Actualizador automático de la base de datos
 
@@ -42,12 +42,12 @@ Do you want to create it? [yes (default) / no]:
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 3: Configuración del servidor](es/server-setup) | [Paso 5: Red >>](es/networking) |
+| [<< Paso 3: Configuración del servidor](server-setup) | [Paso 5: Red >>](networking) |

--- a/docs/es/database-manual-setup.md
+++ b/docs/es/database-manual-setup.md
@@ -8,7 +8,7 @@ redirect_from: "/Database-Manual-Setup"
 
 ### Cliente MySQL
 
-Para configurar tu base de datos, puedes usar el cliente MySQL que prefieras. Algunos ejemplos [aquí](es/Database-client).
+Para configurar tu base de datos, puedes usar el cliente MySQL que prefieras. Algunos ejemplos [aquí](Database-client).
 
 Asumiremos que ya sabes cómo realizar las tareas básicas como crear una nueva base de datos, seleccionar una base de datos e importar un archivo de volcado SQL. Si no lo sabes, no te preocupes: es muy fácil y encontrarás muchas guías en Google, sea cual sea el cliente MySQL que uses.
 

--- a/docs/es/debian12-install-guide.md
+++ b/docs/es/debian12-install-guide.md
@@ -1,6 +1,6 @@
 # Guía de instalación de AzerothCore en Debian 12
 
-Esta es una guía de inicio rápido para instalar AzerothCore en un servidor Debian 12 desde tu PC con Windows. Para un tutorial más detallado, consulta la [Guía de instalación oficial de AzerothCore](es/installation).
+Esta es una guía de inicio rápido para instalar AzerothCore en un servidor Debian 12 desde tu PC con Windows. Para un tutorial más detallado, consulta la [Guía de instalación oficial de AzerothCore](installation).
 
 
 ## Tabla de contenidos
@@ -333,6 +333,6 @@ acoreupdate
 - Backups automáticos de la base de datos a Google Drive usando cron y rclone.
 
 ### Otros recursos {#other-resources}
-- [Guía de instalación oficial de AzerothCore](es/installation)
-- [Tutorial de Debian de heyaapl](es/digital-ocean-video-tutorial)
+- [Guía de instalación oficial de AzerothCore](installation)
+- [Tutorial de Debian de heyaapl](digital-ocean-video-tutorial)
 - [Video de Digital Scriptorium](https://www.youtube.com/watch?v=k4i4za1Scgg)

--- a/docs/es/disables.md
+++ b/docs/es/disables.md
@@ -1,6 +1,6 @@
 # disables
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla \`disables\`**
 

--- a/docs/es/faq.md
+++ b/docs/es/faq.md
@@ -4,9 +4,9 @@ tableofcontents: 1
 
 # Preguntas frecuentes
 
-Si tienes problemas para instalar o compilar AzerothCore, lee [Errores comunes](es/common-errors).
+Si tienes problemas para instalar o compilar AzerothCore, lee [Errores comunes](common-errors).
 
-| ¿Estas preguntas frecuentes no respondieron a tus dudas? Lee [Cómo pedir ayuda](es/how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
+| ¿Estas preguntas frecuentes no respondieron a tus dudas? Lee [Cómo pedir ayuda](how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
 | --- |
 
 ## Preguntas frecuentes generales
@@ -24,21 +24,21 @@ Si tienes problemas para instalar o compilar AzerothCore, lee [Errores comunes](
   - Aunque nos esforzamos por ofrecer contenido blizzlike, también valoramos la experiencia del usuario. Esto significa que a veces corregimos bugs o exploits que existían en el juego original en su momento para ofrecer una mejor experiencia general a los jugadores.
 
 - ¿Cómo puedo contribuir?
-  - Puedes ayudar a corregir issues enviando Pull Requests, lee más [aquí](es/contribute).
-  - Puedes ayudarnos probando nuestros [Pull Requests](es/contribute#how-to-test-a-pull-request) y participando en las [discusiones de los issues de github](https://github.com/azerothcore/azerothcore-wotlk/issues).
+  - Puedes ayudar a corregir issues enviando Pull Requests, lee más [aquí](contribute).
+  - Puedes ayudarnos probando nuestros [Pull Requests](contribute#how-to-test-a-pull-request) y participando en las [discusiones de los issues de github](https://github.com/azerothcore/azerothcore-wotlk/issues).
   - Puedes ayudar a mejorar la wiki enviando un [Pull Request](https://github.com/azerothcore/wiki).
 
 - ¿Por qué no fusionáis mi corrección?
   - Todas las correcciones deben ser revisadas por un desarrollador. Los desarrolladores no lo saben todo, así que necesitas esperar hasta que alguien la revise.
   - Algunas correcciones requieren pruebas y no todos los desarrolladores pueden probar, así que necesitas esperar a que alguien más la pruebe.
   - Se fusionan eventualmente tras obtener la etiqueta To Be Merged.
-  - Quizás no estés siguiendo los [estándares SQL/C++](es/standard-operating-procedure).
-  - Lee más en [Merge Process](es/merge-process).
+  - Quizás no estés siguiendo los [estándares SQL/C++](standard-operating-procedure).
+  - Lee más en [Merge Process](merge-process).
 
 - ¿Cómo reporto un crash?
   - Pegando tu crashlog en un PasteBin o Gist.
   - El crashlog **debe provenir de una compilación RelWithDebInfo o Debug**. Si es de Release, es inútil.
-  - [Cómo reiniciar y depurar](es/how-to-restart-and-debug).
+  - [Cómo reiniciar y depurar](how-to-restart-and-debug).
 
 - ¿Soportáis Repacks basados en AzerothCore?
   - No. Los Repacks NO están soportados y recomendamos encarecidamente no usarlos por [varias razones](https://www.mangosrumors.org/why-you-should-not-use-repacks-to-run-your-wow-server/). Puedes consultar [este tutorial](https://www.chromiecraft.com/how-to-install-a-wow-server-on-your-own-computer/) para una forma sencilla de instalar AC sin usar ningún repack.
@@ -49,14 +49,14 @@ Si tienes problemas para instalar o compilar AzerothCore, lee [Errores comunes](
   - La base de datos se actualiza casi todos los días.
 
 - ¿Cómo actualizo la base de datos?
-  - Puedes encontrar todo lo que necesitas para mantener la base de datos actualizada en esta guía sobre [Base de datos: mantener el servidor actualizado](es/database-keeping-the-server-up-to-date).
+  - Puedes encontrar todo lo que necesitas para mantener la base de datos actualizada en esta guía sobre [Base de datos: mantener el servidor actualizado](database-keeping-the-server-up-to-date).
 
 ## Preguntas frecuentes sobre el core
 
 - ¿Cuándo será estable el código fuente?
   - Pronto...™
   - Hacemos nuestro mejor esfuerzo para mantener la rama master estable y jugable. Nunca subimos código directamente a la rama master, sino que primero requerimos que todos (incluidos los administradores y el staff de AC) abran un PR para que todos puedan revisarlo antes de que se fusione en master.
-  - Por favor, ayúdanos [probando PRs](es/how-to-test-a-pr) y reportando cualquier bug que encuentres.
+  - Por favor, ayúdanos [probando PRs](how-to-test-a-pr) y reportando cualquier bug que encuentres.
 
 - No puedo ejecutar los extractores en plataformas Windows, ¿simplemente desaparece cuando hago click en él?
   - Ten en cuenta que es una herramienta de **línea de comandos**, no una herramienta con GUI. Esto significa que necesitas usar la línea de comandos en Windows (por ejemplo, "Símbolo del sistema") en lugar de hacer doble click en ella.
@@ -81,25 +81,25 @@ Si tienes problemas para instalar o compilar AzerothCore, lee [Errores comunes](
 - Me faltan las librerías de MySQL y no parece que pueda encontrarlas en el repositorio, ¿qué ocurre?
   - La librería se llama "mysql.lib" y no la proporciona AzerothCore.
   - Asegúrate de haber instalado tu MySQL-Server con los DEVELOPMENT HEADERS.
-  - Puedes seguir la guía de [Instalación del Core](es/core-installation) para encontrar las librerías.
+  - Puedes seguir la guía de [Instalación del Core](core-installation) para encontrar las librerías.
 
 - Me faltan las librerías de OpenSSL y no parece que pueda encontrarlas en el repositorio, ¿qué ocurre?
   - Necesitas las siguientes dll:
     - legacy.dll
     - libcrypto-3-x64.dll
     - libssl-3-x64.dll
-  - Puedes seguir la guía de [Instalación del Core](es/core-installation) para encontrar las librerías.
+  - Puedes seguir la guía de [Instalación del Core](core-installation) para encontrar las librerías.
 
 ## Preguntas frecuentes sobre depuración
 
 - ¿Cómo puedo obtener un buen crashlog en Windows?
   - Compila tu core en RelWithDebInfo o Debug. Un crashlog de Release será inútil.
-  - Puedes depurarlo tú mismo si [ejecutas worldserver y authserver en Visual Studio](es/run-worldserver-and-authserver-in-visual-studio).
+  - Puedes depurarlo tú mismo si [ejecutas worldserver y authserver en Visual Studio](run-worldserver-and-authserver-in-visual-studio).
 
 ## Preguntas frecuentes sobre módulos
 
 - Necesito un nuevo hook para mi módulo personalizado, ¿qué puedo hacer?
-  - Puedes añadir el hook a tu propio fork (cf: [crear un nuevo hook](es/hooks-script)) y crear un nuevo Pull Request al repositorio oficial para que podamos validarlo y fusionarlo.
+  - Puedes añadir el hook a tu propio fork (cf: [crear un nuevo hook](hooks-script)) y crear un nuevo Pull Request al repositorio oficial para que podamos validarlo y fusionarlo.
 
 - ¿Es posible convertir un parche del core en un módulo?
   - Sí. [Is it possible to turn a core patch into a module for AzerothCore? - StackOverflow](https://stackoverflow.com/questions/66340549/is-it-possible-to-turn-a-core-patch-into-a-module-for-azerothcore/66340683#66340683).
@@ -114,7 +114,7 @@ Si tienes problemas para instalar o compilar AzerothCore, lee [Errores comunes](
   - Sí funciona, pero no con un 100% de tasa de éxito. Warden no detecta todos los hacks, ni siquiera en Retail.
 
 - ¿Cómo cierro una instancia o campo de batalla? ¿Cómo puedo desactivar un hechizo?
-  - Todas las desactivaciones se manejan en la [tabla disables](es/disables).
+  - Todas las desactivaciones se manejan en la [tabla disables](disables).
 
-| ¿Estas preguntas frecuentes no respondieron a tus dudas? Lee [Cómo pedir ayuda](es/how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
+| ¿Estas preguntas frecuentes no respondieron a tus dudas? Lee [Cómo pedir ayuda](how-to-ask-for-help) sobre cómo proceder con tu pregunta de la mejor manera. |
 | --- |

--- a/docs/es/final-server-steps.md
+++ b/docs/es/final-server-steps.md
@@ -3,13 +3,13 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 5: Red](es/networking) | [Paso 7: Mantener el servidor actualizado >>](es/keeping-the-server-up-to-date) |
+| [<< Paso 5: Red](networking) | [Paso 7: Mantener el servidor actualizado >>](keeping-the-server-up-to-date) |
 
 ## Iniciar el servidor
 
 - Ejecuta authserver y worldserver en tu carpeta de build.
 
-Para información detallada sobre cómo configurar un reiniciador y un debugger, ve a la página [how-to-restart-and-debug](es/how-to-restart-and-debug)
+Para información detallada sobre cómo configurar un reiniciador y un debugger, ve a la página [how-to-restart-and-debug](how-to-restart-and-debug)
 
 {% include warning.html content="¡NUNCA crees una cuenta directamente en tu base de datos a menos que estés ABSOLUTAMENTE SEGURO de que sabes qué hacer y cómo hacerlo!" %}
 
@@ -27,22 +27,22 @@ Para información detallada sobre cómo configurar un reiniciador y un debugger,
 
 ## Crear una cuenta
 
-Lee [creación de cuentas](es/creating-accounts).
+Lee [creación de cuentas](creating-accounts).
 
 ## Configurar el acceso remoto
 
-Para propósitos de desarrollo, este paso no es necesario. Sin embargo, para mayor seguridad cuando quieras que otras personas creen cuentas, deberías configurar un formulario de registro, así no tienes que pegar sus contraseñas. Consulta [Acceso remoto](es/remote-access) sobre cómo enviar comandos al servidor.
+Para propósitos de desarrollo, este paso no es necesario. Sin embargo, para mayor seguridad cuando quieras que otras personas creen cuentas, deberías configurar un formulario de registro, así no tienes que pegar sus contraseñas. Consulta [Acceso remoto](remote-access) sobre cómo enviar comandos al servidor.
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 5: Red](es/networking) | [Paso 7: Mantener el servidor actualizado >>](es/keeping-the-server-up-to-date) |
+| [<< Paso 5: Red](networking) | [Paso 7: Mantener el servidor actualizado >>](keeping-the-server-up-to-date) |

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -4,7 +4,7 @@
 
 ¿Te gustaría aprender sobre AzerothCore (AC), configurar tu servidor de WoW por primera vez, entender cómo modificarlo y ser capaz de contribuir? ¡Has llegado al lugar correcto!
 
-Empezar con la emulación de WoW puede resultar complicado al principio, pero no te preocupes, estaremos ahí para ayudarte en caso de que encuentres algún problema o tengas alguna pregunta. Solo lee [esta página](es/How-to-ask-for-help) antes de pedir ayuda.
+Empezar con la emulación de WoW puede resultar complicado al principio, pero no te preocupes, estaremos ahí para ayudarte en caso de que encuentres algún problema o tengas alguna pregunta. Solo lee [esta página](How-to-ask-for-help) antes de pedir ayuda.
 
 Si mientras lees cualquiera de los tutoriales enlazados en esta página encuentras algo que no está claro: háznoslo saber. Haremos lo posible por reformularlo y hacerlo más fácil de entender para los principiantes. ¡Mejorar la documentación también es una forma de contribuir!
 
@@ -47,7 +47,7 @@ Básicamente, hay 3 formas principales de instalar AC:
 
 Puedes elegir una configuración, o incluso probar más de una. Puedes encontrar todas las instrucciones aquí:
 
-- [azerothcore.org/wiki/Installation](es/installation)
+- [azerothcore.org/wiki/Installation](installation)
 
 Si encuentras algún problema o duda al intentar instalar tu servidor de AC, [pídenos ayuda](https://github.com/azerothcore/wiki/blob/master/docs/how-to-ask-for-help).
 
@@ -57,10 +57,10 @@ Si encuentras algún problema o duda al intentar instalar tu servidor de AC, [p�
 
 ## Accede al juego, aprende los comandos GM
 
-Antes que nada, asegúrate de que tu cliente tenga su realmlist.wtf configurado con lo siguiente: `set realmlist localhost`. Después de esto (asumiendo que ya has configurado AzerothCore) asegúrate de tener creada una cuenta `GM` (con seguridad de 2 o superior). Si no has creado una cuenta o no estás seguro, sigue esto: [Crear cuentas](es/creating-accounts).
+Antes que nada, asegúrate de que tu cliente tenga su realmlist.wtf configurado con lo siguiente: `set realmlist localhost`. Después de esto (asumiendo que ya has configurado AzerothCore) asegúrate de tener creada una cuenta `GM` (con seguridad de 2 o superior). Si no has creado una cuenta o no estás seguro, sigue esto: [Crear cuentas](creating-accounts).
 Después de esto tu cuenta `GM` podrá usar los siguientes comandos, con un enlace a una lista de todos los comandos abajo:
 
-- [azerothcore.org/wiki/GM-Commands](es/GM-Commands)
+- [azerothcore.org/wiki/GM-Commands](GM-Commands)
 
 Toma confianza con los comandos, los necesitarás para cualquier actividad de administración, testing o desarrollo.
 
@@ -82,7 +82,7 @@ Lanzamos mejoras a AzerothCore a diario. Deberías aprender cómo actualizar tu 
 
 Por eso es **muy importante** que actualices tu servidor de AzerothCore regularmente. Te recomendamos hacerlo al menos una vez por semana. Lee esta guía:
 
-- [azerothcore.org/wiki/Update](es/update)
+- [azerothcore.org/wiki/Update](update)
 
 Después de seguir el procedimiento de actualización, es importante **verificar** que:
 
@@ -97,7 +97,7 @@ Una gran forma de empezar a contribuir es probando los PRs hechos por otros cola
 
 Este tema es tan importante que hay un tutorial dedicado a él:
 
-- [azerothcore.org/wiki/How-to-test-a-PR](es/How-to-test-a-PR)
+- [azerothcore.org/wiki/How-to-test-a-PR](How-to-test-a-PR)
 
 ![image](https://user-images.githubusercontent.com/75517/109370244-d397b480-789f-11eb-9ac7-64d98ca0d33c.png)
 
@@ -120,7 +120,7 @@ Keira3 genera automáticamente el código SQL necesario para crear o cambiar cos
 
 Necesitarás también una herramienta genérica de gestión de bases de datos para gestionar las tablas y sus contenidos.
 
-- [Herramienta de gestión de bases de datos](es/database-management-tool)
+- [Herramienta de gestión de bases de datos](database-management-tool)
 
 ![AzerothCore world database viewed with sequel-ace](https://user-images.githubusercontent.com/75517/109370368-42750d80-78a0-11eb-946c-c0831a02b52b.png)
 
@@ -128,7 +128,7 @@ Necesitarás también una herramienta genérica de gestión de bases de datos pa
 
 Lee siempre la documentación sobre cada tabla con la que trabajes:
 
-- [azerothcore.org/wiki/database-world](es/database-world)
+- [azerothcore.org/wiki/database-world](database-world)
 
 ### SmartAI
 
@@ -138,7 +138,7 @@ En pocas palabras, con SmartAI puedes hacer que una entidad (por ejemplo una Cre
 
 Por ejemplo, puedes hacer que una creature lance un hechizo (acción), cuando su salud baje por debajo del 50% de su salud total (evento), contra un miembro aleatorio del grupo (objetivo).
 
-Técnicamente, el `smart_script` es solo una tabla dentro de la base de datos world (y su documentación se puede encontrar [aquí](es/smart_scripts)). Herramientas como Keira3 te ayudan a trabajar con SmartAI usando una interfaz gráfica práctica.
+Técnicamente, el `smart_script` es solo una tabla dentro de la base de datos world (y su documentación se puede encontrar [aquí](smart_scripts)). Herramientas como Keira3 te ayudan a trabajar con SmartAI usando una interfaz gráfica práctica.
 
 Intenta abrir Keira3, busca cualquier creature que tenga "SmartAI" como "AIName", ábrela y haz click en "SmartAI" en el menú de la derecha.
 Se te presentará un editor visual que te asistirá al trabajar con SmartAI.
@@ -164,7 +164,7 @@ si entiendes cómo funcionan sentencias básicas como `SELECT`, `UPDATE`, `INSER
 
 Puedes enviar tu mejora mediante un PR. Lee esta guía:
 
-- [Cómo crear un Pull Request (PR)](es/how-to-create-a-pr)
+- [Cómo crear un Pull Request (PR)](how-to-create-a-pr)
 
 ## ¡Empieza a contribuir!
 

--- a/docs/es/group_instance.md
+++ b/docs/es/group_instance.md
@@ -1,6 +1,6 @@
 # group\_instance
 
-[<-Volver a: Characters](es/database-characters)
+[<-Volver a: Characters](database-characters)
 
 **Tabla \`group\_instance\`**
 

--- a/docs/es/how-to-ask-for-help.md
+++ b/docs/es/how-to-ask-for-help.md
@@ -14,7 +14,7 @@ Solo queremos que pidas soporte de **la forma apropiada**. Por favor, lee este d
 
 ## Preguntas frecuentes y errores comunes
 
-Primero, te recomendamos leer las [Preguntas frecuentes](es/faq) y los [Errores comunes](es/common-errors) para encontrar la solución a tu problema.
+Primero, te recomendamos leer las [Preguntas frecuentes](faq) y los [Errores comunes](common-errors) para encontrar la solución a tu problema.
 
 ## ¿Por qué es tan importante "la forma apropiada"?
 

--- a/docs/es/how-to-restart-and-debug.md
+++ b/docs/es/how-to-restart-and-debug.md
@@ -47,4 +47,4 @@ Si el servidor falla después de habilitar GDB, encontrarás el archivo crashdum
 
 Nuestra configuración de Docker integra el motor `startup-scripts`. Esto significa que habilitar GDB y gestionar los reinicios también funciona sin problemas dentro del entorno de Docker. Además, nuestro docker-compose.yml usa la [funcionalidad de restart-policy](https://docs.docker.com/config/containers/start-containers-automatically/) para mantener automáticamente los contenedores en funcionamiento tras un fallo o un reinicio del sistema.
 
-Para más información, consulta la documentación de [Instalación con Docker](es/install-with-docker). También encontrarás una guía sobre cómo depurar tu código usando VSCode combinado con su extensión Remote Docker.
+Para más información, consulta la documentación de [Instalación con Docker](install-with-docker). También encontrarás una guía sobre cómo depurar tu código usando VSCode combinado con su extensión Remote Docker.

--- a/docs/es/how-to-test-a-pr.md
+++ b/docs/es/how-to-test-a-pr.md
@@ -18,12 +18,12 @@ Al hacer clic en la etiqueta de arriba se mostrará la lista de todos los PRs qu
 
 Es necesario:
 
-- Tener AzerothCore instalado en tu sistema (ver [Instalación](es/installation)).
+- Tener AzerothCore instalado en tu sistema (ver [Instalación](installation)).
 - Tener una cuenta en GitHub, puede [registrar una aquí](https://github.com/join) de forma gratuita.
 
 ### ¿Y si el PR sólo tiene cambios en la BD (base de datos)?
 
-Algunos PRs sólo tienen cambios en la base de datos (sin cambios en C++). Si ese es el caso, hay un [procedimiento simplificado para probar esos cambios](es/How-to-test-DB-only-changes).
+Algunos PRs sólo tienen cambios en la base de datos (sin cambios en C++). Si ese es el caso, hay un [procedimiento simplificado para probar esos cambios](How-to-test-DB-only-changes).
 
 Si no estás seguro, sigue leyendo aquí y haz la prueba tradicional de PR que servirá para todo tipo de PR.
 
@@ -94,7 +94,7 @@ Básicamente necesitas **recompilar tus fuentes** y **actualizar la BD**.
 
 ### Utilizando la configuración tradicional
 
-Si está utilizando la instalación tradicional, tiene que volver a compilar siguiendo los pasos de la [3) Compilación](es/instalación#3-compilación) de la guía de instalación principal.
+Si está utilizando la instalación tradicional, tiene que volver a compilar siguiendo los pasos de la [3) Compilación](instalación#3-compilación) de la guía de instalación principal.
 
 También necesita actualizar su DB. Puede utilizar el ensamblador de BD para hacerlo, pero normalmente es más rápido importar manualmente los archivos sql pendientes que incluye el PR. Estos archivos se encuentran en `data/sql/updates/pending_db_*`.
 

--- a/docs/es/how-to-use-changelog.md
+++ b/docs/es/how-to-use-changelog.md
@@ -3,7 +3,7 @@
 Todos los cambios que rompen compatibilidad/notables de este proyecto se documentarán en el archivo `/docs/changelog/master`.
 
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-y este proyecto se adhiere al [Versionado Semántico](es/project-versioning).
+y este proyecto se adhiere al [Versionado Semántico](project-versioning).
 
 **Este changelog debería proporcionar una forma sencilla para que los desarrolladores actualicen su propio código que está conectado a AzerothCore** (p. ej. módulos, APIs, scripts, etc.)
 No es una forma de llevar un registro de TODOS los cambios realizados (para eso tenemos el historial de git). Por tanto, solo 2 reglas de oro a seguir:

--- a/docs/es/install-with-docker.md
+++ b/docs/es/install-with-docker.md
@@ -117,7 +117,7 @@ Para separarte (detach), presiona `ctrl+p` y `ctrl+q`. **NO** intentes separarte
 Si obtienes el mensaje de error `the input device is not a TTY.  If you are using mintty, try prefixing the command with 'winpty'`
 
 Este comando adjuntará automáticamente tu terminal a la consola del worldserver.
-Ahora puedes ejecutar el comando `account create <user> <password>` para crear tu primera cuenta dentro del juego. Hay [más información en la página de Creación de cuentas](es/creating-accounts).
+Ahora puedes ejecutar el comando `account create <user> <password>` para crear tu primera cuenta dentro del juego. Hay [más información en la página de Creación de cuentas](creating-accounts).
 
 ### Acceder a la base de datos y actualizar el realmlist
 

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -12,15 +12,15 @@ Hay varias formas de instalar AzerothCore, necesitas elegir **UNA**.
 
 Esta es la forma oficialmente soportada y completa de instalar AzerothCore.
 
-- [Instalación clásica de AzerothCore](es/classic-installation) - Recomendada para Windows, macOS y Linux.
+- [Instalación clásica de AzerothCore](classic-installation) - Recomendada para Windows, macOS y Linux.
 
 ### Instalaciones experimentales (soporte y uso limitados)
 
 Estas guías son para instalaciones experimentales y tienen soporte limitado o nulo.
 
-- [Instalación con el Dashboard Bash de AzerothCore](es/ac-dashboard-core-installation) - la forma más sencilla de instalar.
+- [Instalación con el Dashboard Bash de AzerothCore](ac-dashboard-core-installation) - la forma más sencilla de instalar.
 
-- [Instalación con Docker](es/install-with-docker) - un proceso de instalación basado en Docker. Se recomienda tener conocimientos previos de Docker.
+- [Instalación con Docker](install-with-docker) - un proceso de instalación basado en Docker. Se recomienda tener conocimientos previos de Docker.
 
 - [Instalación con Docker pre-compilado](https://www.azerothcore.org/acore-docker/) - una forma sencilla de instalar AzerothCore. Actualmente no puedes instalar módulos C++, solo scripts de Eluna. Adecuada para clasificación de bugs, reporte de bugs o uso doméstico.
 
@@ -28,23 +28,23 @@ Estas guías son para instalaciones experimentales y tienen soporte limitado o n
 
 Ten en cuenta que estas guías están hechas por miembros de la comunidad y podrían no estar actualizadas:
 
-- [Debian 12](es/debian12-install-guide)
+- [Debian 12](debian12-install-guide)
 
-- [Amazon Web Services](es/aws-tutorial)
+- [Amazon Web Services](aws-tutorial)
 
-- [Digital Ocean droplet](es/digital-ocean-video-tutorial)
+- [Digital Ocean droplet](digital-ocean-video-tutorial)
 
-- [ArchLinux](es/arch-linux)
+- [ArchLinux](arch-linux)
 
-- [FreeBSD](es/freebsd)
+- [FreeBSD](freebsd)
 
-- [Visual Studio Code](es/vsc-requirements)
+- [Visual Studio Code](vsc-requirements)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.

--- a/docs/es/installing-a-module.md
+++ b/docs/es/installing-a-module.md
@@ -3,7 +3,7 @@
 | Guía de instalación |
 | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 8: Configuración del cliente](es/client-setup) |
+| [<< Paso 8: Configuración del cliente](client-setup) |
 
 Añadir un módulo es un paso opcional para alterar la jugabilidad blizzlike que ofrece AzerothCore por defecto.
 
@@ -11,14 +11,14 @@ Añadir un módulo es un paso opcional para alterar la jugabilidad blizzlike que
 
 1. Encuentra un módulo que se ajuste a tus necesidades en el [Catálogo de AzerothCore](https://www.azerothcore.org/catalogue#/).
 2. Clona el repositorio
-    - Clona el repositorio usando Git de la misma forma en que se clonó AzerothCore por primera vez en la [Instalación del Core](es/core-installation). El repositorio debe clonarse dentro del directorio \modules\, p. ej. E:\AzerothCore\modules\
+    - Clona el repositorio usando Git de la misma forma en que se clonó AzerothCore por primera vez en la [Instalación del Core](core-installation). El repositorio debe clonarse dentro del directorio \modules\, p. ej. E:\AzerothCore\modules\
     - Descarga el archivo ZIP del catálogo y extráelo en el directorio \modules\, p. ej. E:\AzerothCore\modules\mod-anticheat
 
 {% include note.html content="Si tu módulo tiene un sufijo, p. ej. -master, ¡debe eliminarse para que el módulo funcione!" %}
 
 ## Recompilar
 
-Para que tu módulo funcione necesitas recompilar el código fuente. Para una guía detallada sobre cómo recompilar, vuelve a leer la [Instalación del Core](es/core-installation).
+Para que tu módulo funcione necesitas recompilar el código fuente. Para una guía detallada sobre cómo recompilar, vuelve a leer la [Instalación del Core](core-installation).
 
 1. Reconfigura y regenera CMake.
     - Para asegurarte de que el módulo se instaló correctamente, puedes comprobar si aparece en los logs de CMake bajo **\* Modules configuration (static)**
@@ -42,12 +42,12 @@ Siempre deberías revisar el archivo README del módulo para ver si se necesitan
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación |
 | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 8: Configuración del cliente](es/client-setup) |
+| [<< Paso 8: Configuración del cliente](client-setup) |

--- a/docs/es/keeping-the-server-up-to-date.md
+++ b/docs/es/keeping-the-server-up-to-date.md
@@ -3,28 +3,28 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |
 
 Los desarrolladores y colaboradores de AzerothCore siempre están trabajando en corregir y añadir nuevas funciones al core. Siempre puedes encontrarlas [aquí](https://github.com/azerothcore/azerothcore-wotlk/commits/master).
 
-[Linux: mantener el servidor actualizado](es/linux-keeping-the-server-up-to-date)
+[Linux: mantener el servidor actualizado](linux-keeping-the-server-up-to-date)
 
-[macOS: mantener el servidor actualizado](es/macos-keeping-the-server-up-to-date)
+[macOS: mantener el servidor actualizado](macos-keeping-the-server-up-to-date)
 
-[Windows: mantener el servidor actualizado](es/windows-keeping-the-server-up-to-date)
+[Windows: mantener el servidor actualizado](windows-keeping-the-server-up-to-date)
 
-[Base de datos: mantener el servidor actualizado](es/database-keeping-the-server-up-to-date)
+[Base de datos: mantener el servidor actualizado](database-keeping-the-server-up-to-date)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |

--- a/docs/es/linux-core-installation.md
+++ b/docs/es/linux-core-installation.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/linux-requirements) | [Paso 3: Configuración del servidor >>](es/linux-server-setup) |
+| [<< Paso 1: Requisitos](linux-requirements) | [Paso 3: Configuración del servidor >>](linux-server-setup) |
 
 ## Directorios de instalación
 
@@ -25,7 +25,7 @@ export AC_CODE_DIR=$HOME/azerothcore
 
 ## Software necesario
 
-Consulta [Requisitos](es/linux-requirements) antes de continuar.
+Consulta [Requisitos](linux-requirements) antes de continuar.
 
 ## Obtener el código fuente
 
@@ -83,7 +83,7 @@ cd build
 
 ### Configurar para compilar {#configuring-for-compiling}
 
-Explicación de los parámetros para usuarios avanzados: [Opciones de CMake](es/cmake-options).
+Explicación de los parámetros para usuarios avanzados: [Opciones de CMake](cmake-options).
 
 En este punto, debes estar en tu directorio `$AC_CODE_DIR/build`.
 
@@ -212,12 +212,12 @@ sudo journalctl ac-worldserver.service
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/linux-requirements) | [Paso 3: Configuración del servidor >>](es/linux-server-setup) |
+| [<< Paso 1: Requisitos](linux-requirements) | [Paso 3: Configuración del servidor >>](linux-server-setup) |

--- a/docs/es/linux-keeping-the-server-up-to-date.md
+++ b/docs/es/linux-keeping-the-server-up-to-date.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |
 
 ## Mantener el código fuente actualizado
 
@@ -20,13 +20,13 @@ make -j$(nproc --all); make install
 ```
 _Puedes reemplazar `-j$(nproc -all)` con el número de cores con los que compilar. Por ejemplo: -j 2_
 
-A veces añadimos o eliminamos archivos del repositorio. En ese momento es necesario recompilar el servidor, tal como se instaló la primera vez [en la Instalación del Core en Linux](es/linux-core-installation#configuring-for-compiling).
+A veces añadimos o eliminamos archivos del repositorio. En ese momento es necesario recompilar el servidor, tal como se instaló la primera vez [en la Instalación del Core en Linux](linux-core-installation#configuring-for-compiling).
 
 ## Usar un servidor de automatización
 
 Si quieres actualizar AzerothCore usando Jenkins, Teamcity o una herramienta similar, los siguientes pasos pueden ayudarte.
 
-Añade los comandos necesarios al archivo sudoers. Los servicios de abajo se crearon [en la Instalación del Core en Linux](es/linux-core-installation#optional-systemd-services)
+Añade los comandos necesarios al archivo sudoers. Los servicios de abajo se crearon [en la Instalación del Core en Linux](linux-core-installation#optional-systemd-services)
 ```sh
 sudo visudo
 
@@ -54,18 +54,18 @@ sudo service authserver start
 
 ## Mantener la base de datos actualizada
 
-Lee [Base de datos: mantener el servidor actualizado](es/database-keeping-the-server-up-to-date)
+Lee [Base de datos: mantener el servidor actualizado](database-keeping-the-server-up-to-date)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |

--- a/docs/es/linux-requirements.md
+++ b/docs/es/linux-requirements.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Guía de instalación](es/classic-installation) | [Paso 2: Instalación del Core >>](es/linux-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation) | [Paso 2: Instalación del Core >>](linux-core-installation) |
 
 | |
 | :- |
@@ -105,12 +105,12 @@ Tu versión de `openssl` **DEBE** ser igual o superior a la versión requerida q
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Guía de instalación](es/classic-installation) | [Paso 2: Instalación del Core >>](es/linux-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation) | [Paso 2: Instalación del Core >>](linux-core-installation) |

--- a/docs/es/linux-server-setup.md
+++ b/docs/es/linux-server-setup.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/linux-core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](linux-core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |
 
 **Tabla de contenidos**
 - [Archivos de datos del cliente (descargar pre-extraídos)](#option-1-download-pre-extracted-files)
@@ -101,7 +101,7 @@ Variablename = "MySQLIP;Port;Username;Password;database"
 Deben verificarse los siguientes pasos:
 
 - El hostname (127.0.0.1) puede quedarse igual si AzerothCore se está instalando en el mismo equipo en el que ejecutas WoW.
-  Si no, sigue las instrucciones de la [tabla Realmlist](es/realmlist).
+  Si no, sigue las instrucciones de la [tabla Realmlist](realmlist).
 
 - El puerto (3306) es el valor estándar configurado. Si cambiaste el puerto por defecto en tu configuración de MySQL, debes cambiarlo en consecuencia.
   El usuario y la contraseña pueden variar. Puedes elegir entre:
@@ -124,18 +124,18 @@ Deben verificarse los siguientes pasos:
 
 ### (Opcional) Opciones de configuración por variable de entorno
 
-Es posible cargar opciones de configuración mediante variables de entorno, sobre lo que puedes leer [aquí](es/config-overrides-with-env-var).
+Es posible cargar opciones de configuración mediante variables de entorno, sobre lo que puedes leer [aquí](config-overrides-with-env-var).
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/linux-core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](linux-core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |

--- a/docs/es/loot_template.md
+++ b/docs/es/loot_template.md
@@ -1,6 +1,6 @@
 # loot_template
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Las tablas \*_loot_template**
 

--- a/docs/es/macos-core-installation.md
+++ b/docs/es/macos-core-installation.md
@@ -3,11 +3,11 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/macos-requirements) | [Paso 3: Configuración del servidor >>](es/macos-server-setup) |
+| [<< Paso 1: Requisitos](macos-requirements) | [Paso 3: Configuración del servidor >>](macos-server-setup) |
 
 ## Software necesario
 
-Consulta [Requisitos](es/macos-requirements) antes de continuar.
+Consulta [Requisitos](macos-requirements) antes de continuar.
 
 ## Obtener el código fuente
 
@@ -54,7 +54,7 @@ Los directorios que Homebrew usa para instalar paquetes difieren entre las Mac c
 
 Antes de ejecutar el comando CMake, reemplaza `$HOME/azeroth-server/` con la ruta de instalación del servidor (donde quieras colocar los binarios compilados).
 
-Explicación de los parámetros para usuarios avanzados: [Opciones de CMake](es/cmake-options).
+Explicación de los parámetros para usuarios avanzados: [Opciones de CMake](cmake-options).
 
 En este punto, debes estar en tu directorio "build/".
 
@@ -102,12 +102,12 @@ make install
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/macos-requirements) | [Paso 3: Configuración del servidor >>](es/macos-server-setup) |
+| [<< Paso 1: Requisitos](macos-requirements) | [Paso 3: Configuración del servidor >>](macos-server-setup) |

--- a/docs/es/macos-keeping-the-server-up-to-date.md
+++ b/docs/es/macos-keeping-the-server-up-to-date.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |
 
 ## Mantener el código fuente actualizado
 
@@ -17,22 +17,22 @@ cd build
 make -j 8; make install
 ```
 
-A veces añadimos o eliminamos archivos del repositorio. En ese momento es necesario recompilar el servidor, tal como se instaló la primera vez [en la Instalación del Core en macOS](es/macos-core-installation#configuring-for-compiling).
+A veces añadimos o eliminamos archivos del repositorio. En ese momento es necesario recompilar el servidor, tal como se instaló la primera vez [en la Instalación del Core en macOS](macos-core-installation#configuring-for-compiling).
 
 ## Mantener la base de datos actualizada
 
-Lee [Base de datos: mantener el servidor actualizado](es/database-keeping-the-server-up-to-date)
+Lee [Base de datos: mantener el servidor actualizado](database-keeping-the-server-up-to-date)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |

--- a/docs/es/macos-requirements.md
+++ b/docs/es/macos-requirements.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Guía de instalación](es/classic-installation) | [Paso 2: Instalación del Core >>](es/macos-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation) | [Paso 2: Instalación del Core >>](macos-core-installation) |
 
 | |
 | :- |
@@ -54,12 +54,12 @@ brew install --cask sequel-ace
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Guía de instalación](es/classic-installation) | [Paso 2: Instalación del Core >>](es/macos-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation) | [Paso 2: Instalación del Core >>](macos-core-installation) |

--- a/docs/es/macos-server-setup.md
+++ b/docs/es/macos-server-setup.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/macos-core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](macos-core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |
 
 **Tabla de contenidos**
 - [Archivos de datos del cliente (descargar pre-extraídos)](#option-1-download-pre-extracted-files)
@@ -112,7 +112,7 @@ Variablename = "MySQLIP;Port;Username;Password;database"
 Deben verificarse los siguientes pasos:
 
 - El hostname (127.0.0.1) puede quedarse igual si AzerothCore se está instalando en el mismo equipo en el que ejecutas WoW.
-  Si no, sigue las instrucciones de la [tabla Realmlist](es/realmlist).
+  Si no, sigue las instrucciones de la [tabla Realmlist](realmlist).
 
 - El puerto (3306) es el valor estándar configurado. Si cambiaste el puerto por defecto en tu configuración de MySQL, debes cambiarlo en consecuencia.
   El usuario y la contraseña pueden variar. Puedes elegir entre:
@@ -133,18 +133,18 @@ Deben verificarse los siguientes pasos:
 
 ### (Opcional) Opciones de configuración por variable de entorno
 
-Es posible cargar opciones de configuración mediante variables de entorno, sobre lo que puedes leer [aquí](es/config-overrides-with-env-var).
+Es posible cargar opciones de configuración mediante variables de entorno, sobre lo que puedes leer [aquí](config-overrides-with-env-var).
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/macos-core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](macos-core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |

--- a/docs/es/networking.md
+++ b/docs/es/networking.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 4: Instalación de la base de datos](es/database-installation) | [Paso 6: Pasos finales del servidor >>](es/final-server-steps) |
+| [<< Paso 4: Instalación de la base de datos](database-installation) | [Paso 6: Pasos finales del servidor >>](final-server-steps) |
 
 Esta guía está pensada para configuraciones avanzadas o simplemente para dar más detalles sobre cómo configurar tu reino para uso local o por internet. En general, la configuración por defecto explicada en la guía específica de tu sistema operativo debería ser suficiente para instalaciones simples.
 
@@ -50,12 +50,12 @@ Necesitas asegurarte de que tu aplicación **authserver** dirija las conexiones 
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 4: Instalación de la base de datos](es/database-installation) | [Paso 6: Pasos finales del servidor >>](es/final-server-steps) |
+| [<< Paso 4: Instalación de la base de datos](database-installation) | [Paso 6: Pasos finales del servidor >>](final-server-steps) |

--- a/docs/es/outdoorpvp_template.md
+++ b/docs/es/outdoorpvp_template.md
@@ -1,6 +1,6 @@
 # outdoorpvp_template
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla \`outdoorpvp_template\`**
 

--- a/docs/es/project-versioning.md
+++ b/docs/es/project-versioning.md
@@ -18,7 +18,7 @@ Con más detalle:
 
 * Versión **PATCH** cuando haces arreglos de bugs y de seguridad retrocompatibles.
 
-* **PRERELEASE** esto es lo que se llama "metadata" en el estándar semver. Usamos esta parte del versionado mientras trabajamos en la rama **master**. Cada vez que se lanza una nueva funcionalidad o un cambio que rompe compatibilidad (tanto en código como en BD), este número se incrementa para notificarte sobre posibles acciones a realizar. Consulta [cómo usar el changelog](es/how-to-use-changelog).
+* **PRERELEASE** esto es lo que se llama "metadata" en el estándar semver. Usamos esta parte del versionado mientras trabajamos en la rama **master**. Cada vez que se lanza una nueva funcionalidad o un cambio que rompe compatibilidad (tanto en código como en BD), este número se incrementa para notificarte sobre posibles acciones a realizar. Consulta [cómo usar el changelog](how-to-use-changelog).
 
 ### PRERELEASE primero
 

--- a/docs/es/requirements.md
+++ b/docs/es/requirements.md
@@ -5,24 +5,24 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Instalación clásica](es/classic-installation) | [Paso 2: Instalación del Core >>](es/core-installation) |
+| [<< Inicio: Instalación clásica](classic-installation) | [Paso 2: Instalación del Core >>](core-installation) |
 
-[Requisitos de Linux](es/linux-requirements)
+[Requisitos de Linux](linux-requirements)
 
-[Requisitos de macOS](es/macos-requirements)
+[Requisitos de macOS](macos-requirements)
 
-[Requisitos de Windows](es/windows-requirements)
+[Requisitos de Windows](windows-requirements)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Instalación clásica](es/classic-installation) | [Paso 2: Instalación del Core >>](es/core-installation) |
+| [<< Inicio: Instalación clásica](classic-installation) | [Paso 2: Instalación del Core >>](core-installation) |

--- a/docs/es/scene_template.md
+++ b/docs/es/scene_template.md
@@ -1,6 +1,6 @@
 # scene\_template
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla \`scene\_template\`**
 

--- a/docs/es/scripts.md
+++ b/docs/es/scripts.md
@@ -1,6 +1,6 @@
 # Tablas de scripts
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 # Tablas: \*\*\*\_scripts
 

--- a/docs/es/server-setup.md
+++ b/docs/es/server-setup.md
@@ -3,24 +3,24 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |
 
-[Configuración del servidor en Linux](es/linux-server-setup)
+[Configuración del servidor en Linux](linux-server-setup)
 
-[Configuración del servidor en macOS](es/macos-server-setup)
+[Configuración del servidor en macOS](macos-server-setup)
 
-[Configuración del servidor en Windows](es/windows-server-setup)
+[Configuración del servidor en Windows](windows-server-setup)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |

--- a/docs/es/smart_scripts.md
+++ b/docs/es/smart_scripts.md
@@ -4,7 +4,7 @@ redirect_from: "/sai"
 
 # smart_scripts
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 La tabla `smart_scripts` tiene 31 atributos. Sirve para hacer scripts en lenguaje SQL. Lo importante es analizar siempre cuál es el evento que motiva la ejecución de una acción y, por supuesto, cuál es el objetivo. Como recomendación, puedes revisar los scripts que ya están dentro de la tabla para entender cómo funciona. La ventaja, por la que varios usan este método, es que no se requiere compilar al añadir registros; con reiniciar el servidor, si está bien programado, puedes apreciar los cambios. Otra razón es la portabilidad, pero eso depende del punto de vista del desarrollador y de la respuesta que puedas obtener.
 

--- a/docs/es/summonproperties_dbc.md
+++ b/docs/es/summonproperties_dbc.md
@@ -1,8 +1,8 @@
 # summonproperties\_dbc
 
-[`Back-to:Spell Effects Reference`](es/spell-effects-reference)
+[`Back-to:Spell Effects Reference`](spell-effects-reference)
 
-[`Back-to:DBC`](es/dbc-index)
+[`Back-to:DBC`](dbc-index)
 
 **Tabla \`summonproperties\_dbc\`**
 
@@ -10,7 +10,7 @@ Este DBC contiene las Summon Properties (EffectMiscValueB) para el Spell Effect 
 
 **La versión es: 3.3.5a**
 
-[Cómo importar datos DBC a mi base de datos](es/how-to-import-dbc-data-in-db)  
+[Cómo importar datos DBC a mi base de datos](how-to-import-dbc-data-in-db)  
 
 **Estructura**
 
@@ -49,7 +49,7 @@ Este es el ID de SummonProperties.dbc.
 
 ### Faction
 
-ID de [Faction.dbc](es/faction).
+ID de [Faction.dbc](faction).
 
 ### Title
 

--- a/docs/es/version.md
+++ b/docs/es/version.md
@@ -1,6 +1,6 @@
 # version
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla \`version\`**
 

--- a/docs/es/vsc-requirements.md
+++ b/docs/es/vsc-requirements.md
@@ -2,7 +2,7 @@
 
 | Guía de instalación | |
 | :- | :- |
-| [<< Inicio: Guía de instalación](es/installation) | [Paso 2: Instalación del Core con VSC >>](es/windows-vsc-core-installation) |
+| [<< Inicio: Guía de instalación](installation) | [Paso 2: Instalación del Core con VSC >>](windows-vsc-core-installation) |
 
 | |
 | :- |
@@ -59,7 +59,7 @@
        *Si necesitas soporte de 32 bits, descarga e instala el [Microsoft Visual C++ 2008 Redistributable Package (x86)](http://www.microsoft.com/en-us/download/details.aspx?id=15336).*
        
     1. *Nota #2: Al instalar OpenSSL, elige el directorio de binarios de OpenSSL (/bin) (NO "The Windows system directory")*
-       *cuando se te dé a elegir dónde copiar las DLLs de OpenSSL. Estas DLLs deberán poder localizarse fácilmente para la [Instalación del Core](es/windows-core-installation).*
+       *cuando se te dé a elegir dónde copiar las DLLs de OpenSSL. Estas DLLs deberán poder localizarse fácilmente para la [Instalación del Core](windows-core-installation).*
 
 1. [Boost](https://www.boost.org/).
 

--- a/docs/es/warden_checks.md
+++ b/docs/es/warden_checks.md
@@ -1,6 +1,6 @@
 # warden\_checks
 
-[<-Volver a: World](es/database-world)
+[<-Volver a: World](database-world)
 
 **Tabla \`warden\_checks\`**
 

--- a/docs/es/windows-core-installation.md
+++ b/docs/es/windows-core-installation.md
@@ -3,11 +3,11 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/windows-requirements) | [Paso 3: Configuración del servidor >>](es/windows-server-setup) |
+| [<< Paso 1: Requisitos](windows-requirements) | [Paso 3: Configuración del servidor >>](windows-server-setup) |
 
 ## Software necesario
 
-Consulta [Requisitos](es/windows-requirements) antes de continuar.
+Consulta [Requisitos](windows-requirements) antes de continuar.
 
 ## Descarga y compilación del código fuente
 
@@ -32,7 +32,7 @@ Haz click en **Clone**. En pocos minutos, los archivos fuente de Azerothcore se 
 
 #### Solución de problemas
 
-Si te encuentras con un error como **fatal: early EOF** o **fatal: fetch-pack: invalid index-pack output**, puedes encontrar una solución alternativa aquí: [Errores comunes ACE00105](es/common-errors#ace00105).
+Si te encuentras con un error como **fatal: early EOF** o **fatal: fetch-pack: invalid index-pack output**, puedes encontrar una solución alternativa aquí: [Errores comunes ACE00105](common-errors#ace00105).
 
 ### Configuración y generación de la solución Visual C++ con CMake
 
@@ -46,7 +46,7 @@ Antes de comenzar, crea un nuevo directorio llamado **Build**. En esta guía, us
 
 1. Haz click en **Configure**.
 
-1. En el menú desplegable, elige la versión del compilador que descargaste en la sección de [Requisitos](es/windows-requirements). Asegúrate de elegir la versión **Win64** si trabajas en una compilación de 64 bits.
+1. En el menú desplegable, elige la versión del compilador que descargaste en la sección de [Requisitos](windows-requirements). Asegúrate de elegir la versión **Win64** si trabajas en una compilación de 64 bits.
 
 1. Asegúrate de que **Use default native compilers** esté marcado.
 
@@ -58,7 +58,7 @@ Antes de comenzar, crea un nuevo directorio llamado **Build**. En esta guía, us
 
 1. Haz click en **Generate**. Esto instalará los archivos de build seleccionados en tu carpeta **C:\Build**.
 
-{% include note.html content="Si te encuentras con errores en CMake, consulta [Errores comunes](es/common-errors#core-installation-errors)." %}
+{% include note.html content="Si te encuentras con errores en CMake, consulta [Errores comunes](common-errors#core-installation-errors)." %}
 
 ### Compilación del código fuente {#compiling-the-source}
 
@@ -127,12 +127,12 @@ Los archivos pdb solo existen si compilas con la configuración Debug o RelWithD
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 1: Requisitos](es/windows-requirements) | [Paso 3: Configuración del servidor >>](es/windows-server-setup) |
+| [<< Paso 1: Requisitos](windows-requirements) | [Paso 3: Configuración del servidor >>](windows-server-setup) |

--- a/docs/es/windows-keeping-the-server-up-to-date.md
+++ b/docs/es/windows-keeping-the-server-up-to-date.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |
 
 ## Mantener el código fuente actualizado
 
@@ -15,22 +15,22 @@ Esto sincronizará tu repositorio local con los últimos commits del repositorio
 
 1. Ahora necesitarás volver a ejecutar CMake Configure y Generate para actualizar los archivos de tu solución (.sln).
 
-1. Compila el código fuente descargado como se explica en [Instalación del Core en Windows](es/windows-core-installation#compiling-the-source)
+1. Compila el código fuente descargado como se explica en [Instalación del Core en Windows](windows-core-installation#compiling-the-source)
 
 ## Mantener la base de datos actualizada
 
-Lee [Base de datos: mantener el servidor actualizado](es/database-keeping-the-server-up-to-date)
+Lee [Base de datos: mantener el servidor actualizado](database-keeping-the-server-up-to-date)
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 6: Pasos finales del servidor](es/final-server-steps) | [Paso 8: Configuración del cliente >>](es/client-setup) |
+| [<< Paso 6: Pasos finales del servidor](final-server-steps) | [Paso 8: Configuración del cliente >>](client-setup) |

--- a/docs/es/windows-requirements.md
+++ b/docs/es/windows-requirements.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Guía de instalación](es/classic-installation) | [Paso 2: Instalación del Core >>](es/windows-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation) | [Paso 2: Instalación del Core >>](windows-core-installation) |
 
 {% include callout.html content="Windows ≥ 10<br/>
 Boost ≥ 1.78<br/>
@@ -84,7 +84,7 @@ MS Visual Studio (Community) ≥ 17 (2022) (Desktop) (Sin preview)" type="info" 
 
     {% include note.html content="Si obtienes el error 'Missing Microsoft Visual C++ .... Redistributable' al instalar OpenSSL, descarga el [Microsoft Visual C++ 2017/2019/2022 Redistributable Package (x64) (Descarga directa)](https://aka.ms/vs/17/release/vc_redist.x64.exe) (instalador de 1.7MB) e instálalo." %}
 
-    {% include note.html content="Al instalar OpenSSL, elige el directorio de binarios de OpenSSL (/bin), NO el directorio del sistema de Windows, cuando te den a elegir dónde copiar las DLL de OpenSSL. Estas DLL deberán poder localizarse fácilmente para la [Instalación del Core](es/windows-core-installation)." %}
+    {% include note.html content="Al instalar OpenSSL, elige el directorio de binarios de OpenSSL (/bin), NO el directorio del sistema de Windows, cuando te den a elegir dónde copiar las DLL de OpenSSL. Estas DLL deberán poder localizarse fácilmente para la [Instalación del Core](windows-core-installation)." %}
 
 8. [Boost](https://www.boost.org/).
 
@@ -102,12 +102,12 @@ MS Visual Studio (Community) ≥ 17 (2022) (Desktop) (Sin preview)" type="info" 
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Inicio: Guía de instalación](es/classic-installation) | [Paso 2: Instalación del Core >>](es/windows-core-installation) |
+| [<< Inicio: Guía de instalación](classic-installation) | [Paso 2: Instalación del Core >>](windows-core-installation) |

--- a/docs/es/windows-server-setup.md
+++ b/docs/es/windows-server-setup.md
@@ -3,7 +3,7 @@
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/windows-core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](windows-core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |
 
 **Tabla de contenidos**
 - [Archivos de datos del cliente (descargar pre-extraídos)](#option-1-download-pre-extracted-files)
@@ -93,7 +93,7 @@ Variablename = "MySQLIP;Port;Username;Password;database"
 Deben verificarse los siguientes pasos:
 
 - El hostname (127.0.0.1) puede quedarse igual si AzerothCore se está instalando en el mismo equipo en el que ejecutas WoW.
-  Si no, sigue las instrucciones de la [tabla Realmlist](es/realmlist).
+  Si no, sigue las instrucciones de la [tabla Realmlist](realmlist).
 
 - El puerto (3306) es el valor estándar configurado. Si cambiaste el puerto por defecto en tu configuración de MySQL, debes cambiarlo en consecuencia.
   El usuario y la contraseña pueden variar. Puedes elegir entre:
@@ -114,18 +114,18 @@ Deben verificarse los siguientes pasos:
 
 ### (Opcional) Opciones de configuración por variable de entorno
 
-Es posible cargar opciones de configuración mediante variables de entorno, sobre lo que puedes leer [aquí](es/config-overrides-with-env-var).
+Es posible cargar opciones de configuración mediante variables de entorno, sobre lo que puedes leer [aquí](config-overrides-with-env-var).
 
 ## Ayuda
 
 Si sigues teniendo problemas, comprueba:
 
-- [Preguntas frecuentes](es/faq)
-- [Errores comunes](es/common-errors)
-- [Cómo pedir ayuda](es/how-to-ask-for-help)
+- [Preguntas frecuentes](faq)
+- [Errores comunes](common-errors)
+- [Cómo pedir ayuda](how-to-ask-for-help)
 - [Únete a nuestro servidor de Discord](https://discord.gg/gkt4y2x), pero no es un canal de soporte 24/7. Un miembro del staff te responderá cuando tenga tiempo.
 
 | Guía de instalación | |
 | :- | :- |
 | Este artículo es parte de la Guía de instalación. Puedes leerlo solo o hacer click en el enlace anterior para moverte fácilmente entre los pasos. |
-| [<< Paso 2: Instalación del Core](es/windows-core-installation) | [Paso 4: Instalación de la base de datos >>](es/database-installation) |
+| [<< Paso 2: Instalación del Core](windows-core-installation) | [Paso 4: Instalación de la base de datos >>](database-installation) |

--- a/docs/es/windows-vsc-core-installation.md
+++ b/docs/es/windows-vsc-core-installation.md
@@ -2,11 +2,11 @@
 
 | Guía de instalación | |
 | :- | :- |
-| [<< Paso 1: Requisitos de VSC](es/vsc-requirements) | [Paso 3: Configuración del servidor >>](es/server-setup) |
+| [<< Paso 1: Requisitos de VSC](vsc-requirements) | [Paso 3: Configuración del servidor >>](server-setup) |
 
 ## Software requerido
 
-Consulta los [Requisitos](es/requirements) antes de continuar.
+Consulta los [Requisitos](requirements) antes de continuar.
 
 ## Descargar y compilar la fuente
 
@@ -40,7 +40,7 @@ Antes de empezar, crea un nuevo directorio llamado **Build**. En esta guía usar
 
 1. Haz click en **Configure**.
 
-1. En el menú desplegable, elige la versión del compilador que descargaste en la sección de [Requisitos](es/windows-requirements). Asegúrate de elegir la versión **Win64** si trabajas en una compilación de 64 bits.
+1. En el menú desplegable, elige la versión del compilador que descargaste en la sección de [Requisitos](windows-requirements). Asegúrate de elegir la versión **Win64** si trabajas en una compilación de 64 bits.
 
 1. Asegúrate de que **Use default native compilers** esté marcado.
 
@@ -137,4 +137,4 @@ Para reportar crashlogs es OBLIGATORIO compilar en modo Debug o RelWithDebInfo.
 
 | Guía de instalación | |
 | :- | :- |
-| [<< Paso 1: Requisitos de VSC](es/vsc-requirements) | [Paso 3: Configuración del servidor >>](es/server-setup) |
+| [<< Paso 1: Requisitos de VSC](vsc-requirements) | [Paso 3: Configuración del servidor >>](server-setup) |


### PR DESCRIPTION
### Description

- Fixes internal relative links in the Spanish wiki that produced a duplicated `/es/` segment in the URL (e.g. `https://www.azerothcore.org/wiki/es/es/linux-requirements`).
- The links were written with an `es/` prefix (`](es/page)`), but since the pages are already served under `/wiki/es/`, the site resolves the relative link against the current directory, yielding a broken `/es/es/` path.
- Removed the redundant `es/` prefix from all in-site relative links (301 links across 53 files), matching the English docs convention where links are relative without a language prefix (`](page)`).
- No content, images, or HTML anchors were affected; encoding preserved as UTF-8 without BOM.

Follow-up to #1231 (Complete Spanish wiki translation).

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

cc @pangolp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Spanish documentation links to use consistent, language-neutral paths.
  * Improved navigation between installation, setup, troubleshooting, database, and contribution guides.
  * Preserved existing instructions, external resources, and Discord links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->