### PR TITLE
docs(es): Fix broken installation anchor link

### DIFF
--- a/docs/es/how-to-test-a-pr.md
+++ b/docs/es/how-to-test-a-pr.md
@@ -94,7 +94,7 @@ Básicamente necesitas **recompilar tus fuentes** y **actualizar la BD**.
 
 ### Utilizando la configuración tradicional
 
-Si está utilizando la instalación tradicional, tiene que volver a compilar siguiendo los pasos de la [3) Compilación](instalación#3-compilación) de la guía de instalación principal.
+Si está utilizando la instalación tradicional, tiene que volver a compilar siguiendo los pasos de la [3) Compilación](installation#3-compiling) de la guía de instalación principal.
 
 También necesita actualizar su DB. Puede utilizar el ensamblador de BD para hacerlo, pero normalmente es más rápido importar manualmente los archivos sql pendientes que incluye el PR. Estos archivos se encuentran en `data/sql/updates/pending_db_*`.
 


### PR DESCRIPTION
### Description

- Fixes a broken internal link in `docs/es/how-to-test-a-pr.md`.
- The "3) Compilación" link pointed to `instalación#3-compilación`, using a translated page slug and heading anchor that do not exist.
- Page filenames and heading anchors are never translated, so the target is now `installation#3-compiling`, matching the English source (`Installation#3-compiling`). The visible Spanish link text is preserved.

Follow-up to #1236 / #1231.

### Related Issue

Closes

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

cc @pangolp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Spanish testing guide to link correctly to the compilation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->