### PR TITLE
docs: surface wiki standards in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 <!---
 Provide a general summary of your changes in the Title above.
-Make sure you have read the WIKI STANDARDS before you submit a PR that changes, adds or removes a wiki page.
-English: https://www.azerothcore.org/wiki/wiki-standards
-Spanish: https://www.azerothcore.org/wiki/es/wiki-standards
 -->
+
+> [!IMPORTANT]
+> Every pull request that adds, changes or removes a wiki page must follow the **WIKI STANDARDS**.
+> Read them first: https://www.azerothcore.org/wiki/wiki-standards
 
 ### Description
 


### PR DESCRIPTION
### Description

The wiki standards were already referenced in the pull request template, but inside the `<!--- --->` comment block, so they never rendered in a PR body. Contributors only saw them if they opened the raw template.

- Moved the reference out of the comment and into an `> [!IMPORTANT]` alert, which GitHub renders in the PR body
- The comment block now keeps only the "summarize your changes in the Title" hint

### Related Issue

Closes #528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template with a prominent reminder to follow WIKI STANDARDS when adding, modifying, or removing wiki pages.
  * Preserved references to the standards in both English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->