### PR TITLE
Update Linux docs for Ubuntu 26.04 toolchain

### DIFF
--- a/docs/common-errors.md
+++ b/docs/common-errors.md
@@ -160,7 +160,7 @@ Reinstall Git for Windows and select "Git from the command line and also 3rd par
 #### ACE00061
 I cannot install AzerothCore on CentOS/Ubuntu/Debian etc.
 
-AzerothCore requires GCC 8.0 or higher and CLang 7 or higher.
+Your distribution is likely too old to provide a supported compiler. Ubuntu 22.04 and older are not supported anymore: use Ubuntu 24.04 or 26.04, or Debian 12/13. See the [supported versions](https://github.com/azerothcore/azerothcore-wotlk/security/policy) for the exact GCC and CLang requirements.
 
 ---------------------------------------------------------
 
@@ -219,6 +219,23 @@ Make sure the version you have installed is supported.
 If you did not download precompiled boost, locate your Boost folder
 1. Run the Bootstrap.bat file
 1. Run the b2.exe file 
+
+---------------------------------------------------------
+
+#### ACE00068
+I can't generate my CMake files on Ubuntu 26.04, I get:
+```
+The C++ compiler "/usr/bin/clang++" is not able to compile a simple test program.
+/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lstdc++: No such file or directory
+```
+
+Clang links against the GCC toolchain, and on Ubuntu 26.04 clang 21 picks GCC 16 while the default `g++` is GCC 15, so the C++ development files it needs are not installed. Install them:
+
+```sh
+sudo apt-get install -y libstdc++-16-dev
+```
+
+If clang picks another version, run `clang++ -v` and install the `libstdc++-<version>-dev` matching the `Selected GCC installation` line of the output.
 
 ## Extractor-related errors
 

--- a/docs/es/common-errors.md
+++ b/docs/es/common-errors.md
@@ -173,7 +173,7 @@ Reinstala Git para Windows y selecciona "Git from the command line and also 3rd 
 
 No puedo instalar AzerothCore en CentOS/Ubuntu/Debian, etc.
 
-AzerothCore requiere GCC 8.0 o superior y CLang 7 o superior.
+Probablemente tu distribución sea demasiado antigua para ofrecer un compilador compatible. Ubuntu 22.04 y anteriores ya no son compatibles: usa Ubuntu 24.04 o 26.04, o Debian 12/13. Consulta las [versiones compatibles](https://github.com/azerothcore/azerothcore-wotlk/security/policy) para conocer los requisitos exactos de GCC y CLang.
 
 ---
 
@@ -238,6 +238,24 @@ Asegúrate de que la versión que tienes instalada es compatible.
 Si no descargaste boost precompilado, localiza tu carpeta de Boost
 1. Ejecuta el archivo Bootstrap.bat
 1. Ejecuta el archivo b2.exe
+
+---
+
+#### ACE00068 {#ace00068}
+
+No puedo generar mis archivos de CMake en Ubuntu 26.04, me aparece:
+```
+The C++ compiler "/usr/bin/clang++" is not able to compile a simple test program.
+/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lstdc++: No such file or directory
+```
+
+Clang enlaza contra el toolchain de GCC y, en Ubuntu 26.04, clang 21 elige GCC 16 mientras que el `g++` predeterminado es GCC 15, así que los archivos de desarrollo de C++ que necesita no están instalados. Instálalos:
+
+```sh
+sudo apt-get install -y libstdc++-16-dev
+```
+
+Si clang elige otra versión, ejecuta `clang++ -v` e instala el `libstdc++-<versión>-dev` que corresponda a la línea `Selected GCC installation` de la salida.
 
 ## Errores relacionados con los extractores
 

--- a/docs/es/how-to-use-gperftool.md
+++ b/docs/es/how-to-use-gperftool.md
@@ -8,9 +8,14 @@ En resumen: thread-friendly heap-checker, heap-profiler, y cpu-profiler.
 
 ## Instalar  (Ubuntu):
 
-Ejecutar en una terminal: `sudo apt-get install google-perftools libgoogle-perftools-dev`
+Ejecutar en una terminal:
+
+- Ubuntu 26.04: `sudo apt-get install libgoogle-perftools-dev`
+- Ubuntu 24.04: `sudo apt-get install google-perftools libgoogle-perftools-dev`
 
 Nota: las dependencias anteriores ya están instaladas en nuestro archivo docker
+
+Ubuntu 26.04 eliminó el paquete `google-perftools`, que es el que proporciona el comando `google-pprof` usado al final de esta página. Allí debes instalar la herramienta [pprof](https://github.com/google/pprof) por separado (`go install github.com/google/pprof@latest`) y usar `pprof` en lugar de `google-pprof`.
 
 ##  Usando (con el tablero AzerothCore):
 

--- a/docs/es/linux-requirements.md
+++ b/docs/es/linux-requirements.md
@@ -17,12 +17,14 @@
 #### Ubuntu 26.04
 
 ```sh
-sudo apt-get update && sudo apt-get install git cmake make gcc g++ clang default-libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev mysql-server libboost-all-dev
+sudo apt-get update && sudo apt-get install git cmake make gcc g++ clang libstdc++-16-dev default-libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev mysql-server libboost-all-dev
 ```
 
 Recuerda que si usas el usuario `root`, no es necesario usar `sudo`.
 
 Ubuntu 26.04 ya ofrece paquetes de MySQL compatibles en los repositorios por defecto, así que el comando anterior es suficiente.
+
+`libstdc++-16-dev` es necesario porque clang 21 (el predeterminado en 26.04) enlaza contra el toolchain de GCC 16, mientras que el `g++` predeterminado es GCC 15 y solo instala los archivos de desarrollo de C++ de GCC 15. Sin él, CMake falla con `cannot find -lstdc++` ([ACE00068](common-errors#ace00068)). Si una futura actualización de Ubuntu cambia la versión de GCC que elige clang, ejecuta `clang++ -v` e instala el `libstdc++-<versión>-dev` que corresponda a la línea `Selected GCC installation`.
 
 ---
 

--- a/docs/how-to-use-gperftool.md
+++ b/docs/how-to-use-gperftool.md
@@ -8,9 +8,14 @@ In short: thread-friendly heap-checker, heap-profiler, and cpu-profiler.
 
 ## Install (Ubuntu):
 
-Run in a terminal: `sudo apt-get install google-perftools libgoogle-perftools-dev`
+Run in a terminal:
+
+- Ubuntu 26.04: `sudo apt-get install libgoogle-perftools-dev`
+- Ubuntu 24.04: `sudo apt-get install google-perftools libgoogle-perftools-dev`
 
 Note: dependencies above are already installed in our docker file
+
+Ubuntu 26.04 dropped the `google-perftools` package, which is the one providing the `google-pprof` command used at the end of this page. Install the [pprof](https://github.com/google/pprof) tool separately there (`go install github.com/google/pprof@latest`) and use `pprof` instead of `google-pprof`.
 
 ## Usage (with the AzerothCore dashboard):
 

--- a/docs/linux-requirements.md
+++ b/docs/linux-requirements.md
@@ -17,12 +17,14 @@
 #### Ubuntu 26.04
 
 ```sh
-sudo apt-get update && sudo apt-get install git cmake make gcc g++ clang default-libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev mysql-server libboost-all-dev
+sudo apt-get update && sudo apt-get install git cmake make gcc g++ clang libstdc++-16-dev default-libmysqlclient-dev libssl-dev libbz2-dev libreadline-dev libncurses-dev mysql-server libboost-all-dev
 ```
 
 Remember that if you are using the `root` user, it is not necessary to use `sudo`.
 
 Ubuntu 26.04 already provides supported MySQL packages through the default repositories, so the command above is enough.
+
+`libstdc++-16-dev` is needed because clang 21 (the default on 26.04) links against the GCC 16 toolchain, while the default `g++` is GCC 15 and only brings the GCC 15 C++ development files. Without it, CMake fails with `cannot find -lstdc++` ([ACE00068](common-errors#ace00068)). If a future Ubuntu update changes the GCC version clang picks, run `clang++ -v` and install the `libstdc++-<version>-dev` matching the `Selected GCC installation` line.
 
 ---
 


### PR DESCRIPTION
### Description

- `linux-requirements`: add `libstdc++-16-dev` to the Ubuntu 26.04 package list, plus a note on why it is needed and how to find the right version with `clang++ -v` if a later update makes clang pick another GCC generation
- `common-errors`: new ACE00068 for the `cannot find -lstdc++` cmake failure, and replace the outdated "GCC 8.0 / CLang 7" answer in ACE00061 with the currently supported distros and a pointer to the security policy
- `how-to-use-gperftool`: Ubuntu 26.04 dropped the `google-perftools` package, so the install command is split per version and `google-pprof` now points at upstream pprof
- Spanish pages updated together with the English ones

Background: on Ubuntu 26.04 the default clang is 21 and links against the GCC 16 toolchain, while the default `g++` is GCC 15 and only brings the GCC 15 C++ dev files, so the cmake compiler test fails. The jemalloc part of the linked issue is already fixed in the core by #26438.

### Related Issue

Related: azerothcore/azerothcore-wotlk#26544

The installer script has the same gap and is fixed separately in azerothcore/azerothcore-wotlk#26940.
