### PR TITLE
docs: add a high-level page for live e2e tests

### DIFF
--- a/_includes/azerothcore/sidebar.html
+++ b/_includes/azerothcore/sidebar.html
@@ -53,6 +53,7 @@
                 <li><a href="/wiki/how-to-create-a-db-pr">How to create a DB PR via GitHub</a></li>
                 <li><a href="/wiki/how-to-test-a-pr">How to test a PR</a></li>
                 <li><a href="/wiki/how-to-test-db-only-changes">How to test DB-only changes</a></li>
+                <li><a href="/wiki/live-e2e">Live e2e tests</a></li>
             </ul>
         </div>
         <div id="es" style="display: none">

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -14,6 +14,8 @@ You can contribute in several ways to AzerothCore:
 
 - [Testing DB-only changes](how-to-test-db-only-changes)
 
+- [Live e2e tests](live-e2e)
+
 - [Creating a pull request](#how-to-create-a-pull-request)
 
 - [Improving our wiki](#improve-the-wiki)
@@ -45,6 +47,7 @@ If **(and only if)** the bug hasn't been reported yet, you can [open an issue](h
 ## How to test a Pull Request
 
 - Read [How to test a PR](how-to-test-a-pr).
+- Official PRs also run [live e2e tests](live-e2e) against a full auth + world + MySQL stack. That does not replace in-game testing.
 
 ## How to create a Pull Request
 

--- a/docs/how-to-test-a-pr.md
+++ b/docs/how-to-test-a-pr.md
@@ -109,6 +109,8 @@ To make sure you are correctly running your server with the PR, check the date a
 
 Now log in game and do your tests!
 
+Official PRs also run [live e2e tests](live-e2e) in CI (full authserver + worldserver, protocol bots). That is extra coverage. It does not replace the in-game checks on this page.
+
 ## What needs to be tested?
 
 Instructions about what needs to be tested in the scope of a PR should be provided by the PR's author in the PR description. If that is not the case, feel free to leave a comment in the PR description asking for testing istructions.

--- a/docs/live-e2e.md
+++ b/docs/live-e2e.md
@@ -14,7 +14,7 @@ This does **not** replace [testing a PR in game](how-to-test-a-pr). It is extra 
 
 On a pull request against `azerothcore/azerothcore-wotlk` (not forks, not drafts), and again on every push to `master`:
 
-1. The usual `nopch-build` job compiles real `authserver` and `worldserver` (ubuntu-24.04, clang-18, no PCH) and uploads those binaries.
+1. The usual `nopch-build` job compiles real `authserver` and `worldserver` (no PCH) and uploads those binaries.
 2. The `e2e full` job starts MySQL and applies the normal AC database and client-data setup.
 3. It boots **those same binaries**. `worldserver` listens on 8085, `authserver` on 3724. The job waits until both ports accept connections.
 4. It runs `go test -tags=e2e` from `e2e/` against that realm.

--- a/docs/live-e2e.md
+++ b/docs/live-e2e.md
@@ -50,7 +50,8 @@ You need a running authserver, worldserver, and MySQL, plus Go 1.26+.
 
 ```bash
 cd e2e
-# copy e2e/.env.example and export E2E_* (auth addr + DSNs)
+cp .env.example .env   # edit auth addr + DSNs
+set -a; source .env; set +a
 go test -tags=e2e ./... -count=1 -v -timeout 120m -parallel 1 -p 1
 ```
 

--- a/docs/live-e2e.md
+++ b/docs/live-e2e.md
@@ -12,18 +12,18 @@ This does **not** replace [testing a PR in game](how-to-test-a-pr). It is extra 
 
 ## What CI does
 
-On a pull request against `azerothcore/azerothcore-wotlk` (not forks, not drafts):
+On a pull request against `azerothcore/azerothcore-wotlk` (not forks, not drafts), and again on every push to `master`:
 
 1. The usual `nopch-build` job compiles real `authserver` and `worldserver` (ubuntu-24.04, clang-18, no PCH) and uploads those binaries.
 2. The `e2e full` job starts MySQL and applies the normal AC database and client-data setup.
 3. It boots **those same binaries**. `worldserver` listens on 8085, `authserver` on 3724. The job waits until both ports accept connections.
 4. It runs `go test -tags=e2e` from `e2e/` against that realm.
 
-So the pipeline runs a **full** AC stack from the PR's binaries, then talks to it as a client. There is no partial worldserver and no mocked combat.
+So the pipeline runs a **full** AC stack from those binaries, then talks to it as a client. There is no partial worldserver and no mocked combat.
 
 A comment in the workflow about "dry-run" is only about the CMake/compile path. The tests themselves always hit a live process.
 
-Merge to `master` keeps the clang-18 build and does **not** run the suite again. Official CI already ran it on the PR.
+The `master` run is the same full suite, not a smoke subset. That catches flakes and cases where an older PR was green against an older `master` but breaks once it lands with later commits.
 
 You can also start the suite by hand with `workflow_dispatch` (`scope=full` or `scope=smoke`).
 

--- a/docs/live-e2e.md
+++ b/docs/live-e2e.md
@@ -1,0 +1,61 @@
+---
+redirect_from: "/Live-e2e"
+---
+
+# Live e2e tests
+
+AzerothCore can run **live end-to-end tests** on a real 3.3.5a realm. They are protocol clients, not a stub of the core and not a dry-run of worldserver.
+
+The bots come from [AzerothGhost](https://github.com/azerothcore/AzerothGhost). They log in through auth, enter the world, and drive the same opcodes a retail client uses (login, teleports, casts, combat, quests, loot, and so on). Assertions look at the protocol, the object cache, and sometimes the character DB.
+
+This does **not** replace [testing a PR in game](how-to-test-a-pr). It is extra coverage on the live stack, mainly so a PR cannot merge while a player-visible path is already broken.
+
+## What CI does
+
+On a pull request against `azerothcore/azerothcore-wotlk` (not forks, not drafts):
+
+1. The usual `nopch-build` job compiles real `authserver` and `worldserver` (ubuntu-24.04, clang-18, no PCH) and uploads those binaries.
+2. The `e2e full` job starts MySQL and applies the normal AC database and client-data setup.
+3. It boots **those same binaries**. `worldserver` listens on 8085, `authserver` on 3724. The job waits until both ports accept connections.
+4. It runs `go test -tags=e2e` from `e2e/` against that realm.
+
+So the pipeline runs a **full** AC stack from the PR's binaries, then talks to it as a client. There is no partial worldserver and no mocked combat.
+
+A comment in the workflow about "dry-run" is only about the CMake/compile path. The tests themselves always hit a live process.
+
+Merge to `master` keeps the clang-18 build and does **not** run the suite again. Official CI already ran it on the PR.
+
+You can also start the suite by hand with `workflow_dispatch` (`scope=full` or `scope=smoke`).
+
+## What the tests are
+
+They live in the AzerothCore repo under `e2e/` (`smoke/` and `suites/`). They import the harness from [AzerothGhost](https://github.com/azerothcore/AzerothGhost) (`e2e/e2eharness`).
+
+Typical flow:
+
+1. Create a GM test account and a character.
+2. Log in and wait until the session is in the world.
+3. Place the bot (named tele, pad, or `.go creature`).
+4. Optionally prepare combat (`.gm off`, cheats, PvP flag).
+5. Drive a real client action (cast, pull, trade, relog, …).
+6. Assert something a player would see (aura gone, HP dropped, still on the bridge, next wave not early, world still alive).
+
+Setup may use GM commands. The oracle should be the player-visible result, not "the GM command returned".
+
+Open core bugs stay commented out with `OPEN(e2e)` and an issue link. They are not compiled, so they cannot soft-pass.
+
+## How to run them locally
+
+You need a running authserver, worldserver, and MySQL, plus Go 1.26+.
+
+```bash
+cd e2e
+# copy e2e/.env.example and export E2E_* (auth addr + DSNs)
+go test -tags=e2e ./... -count=1 -v -timeout 120m -parallel 1 -p 1
+```
+
+Without `-tags=e2e`, `go test ./...` skips these packages.
+
+Keep `-parallel 1 -p 1` unless you know each concurrent package has its own isolation pad. Sharing a pad makes bots thrash each other.
+
+Authoring details: `e2e/README.md` in the core repo, plus AzerothGhost [`LLM_GUIDE.md`](https://github.com/azerothcore/AzerothGhost/blob/main/e2e/LLM_GUIDE.md) and [`EXAMPLES.md`](https://github.com/azerothcore/AzerothGhost/blob/main/e2e/EXAMPLES.md).


### PR DESCRIPTION
> [!IMPORTANT]
> Every pull request that adds, changes or removes a wiki page must follow the **WIKI STANDARDS**.
> Read them first: https://www.azerothcore.org/wiki/wiki-standards

### Description

- Add `docs/live-e2e.md`: official CI boots a full auth + world + MySQL stack from the PR binaries and runs protocol bots against it. This is not a dry-run or a stub of the core.
- The same full suite also runs on every official `master` push, so flakes and merge-base drift show up after squash, not only on the PR head.
- Link the page from Contribute, How to test a PR, and the English sidebar. In-game testing is still required.
- Local run snippet copies `.env.example` after `cd e2e` and sources it before `go test`.

Related: https://github.com/azerothcore/azerothcore-wotlk/pull/27158

### Related Issue

—

## Thank you for contributing to the AzerothCore wiki.

Remember that the wiki is currently available in English and Spanish.

- https://www.azerothcore.org/wiki/home
- https://www.azerothcore.org/wiki/es/home

cc @pangolp — English-only page so far; a Spanish `docs/es/live-e2e.md` would be welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated guide for live end-to-end testing against a real game realm.
  * Documented CI coverage across authentication, world, database, and protocol components.
  * Added instructions for local execution, environment setup, concurrency management, and creating tests.
  * Updated contribution and pull request guidance to include live end-to-end checks alongside in-game testing.
* **Navigation**
  * Added a sidebar link to the live end-to-end testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->