### PR TITLE
docs: Fix broken link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,7 +28,7 @@ These guides are for experimental installations and have limited to no support.
 
 Beware these guides are made by community members and might not be up-to-date:
 
-- [Debian 12](debian12-install-guide)
+- [Debian 13](debian13-install-guide)
 
 - [Amazon Web Services](aws-tutorial)
 


### PR DESCRIPTION
Point to updated Debian13 guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the community Debian installation guide link from Debian 12 to Debian 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->